### PR TITLE
[Feature] DATA-4933: Add Customized Timebased Partitioner 3.3.0

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <property name="localeLanguage" value="en"/>
+
+    <module name="FileTabCharacter"/>
+
+    <!-- header -->
+    <module name="RegexpHeader">
+        <property name="header" value="/\*\nCopyright .* Confluent Inc."/>
+    </module>
+
+    <!-- filters -->
+    <module name="SuppressionCommentFilter"/>
+
+    <module name="TreeWalker">
+
+        <!-- comments -->
+        <module name="FileContentsHolder"/>
+
+        <!-- code cleanup -->
+        <module name="UnusedImports"/>
+        <module name="RedundantImport"/>
+        <module name="IllegalImport" />
+        <module name="EqualsHashCode"/>
+        <module name="SimplifyBooleanExpression"/>
+        <module name="OneStatementPerLine"/>
+        <module name="SimplifyBooleanReturn"/>
+
+        <!-- style -->
+        <module name="DefaultComesLast"/>
+        <module name="EmptyStatement"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="UpperEll"/>
+        <module name="LeftCurly"/>
+        <module name="RightCurly"/>
+        <module name="EmptyStatement"/>
+        <module name="ConstantName">
+            <property name="format" value="(^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$)|(^log$)"/>
+        </module>
+        <module name="LocalVariableName"/>
+        <module name="LocalFinalVariableName"/>
+        <module name="MemberName"/>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="^[A-Z0-9]*$"/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="^[A-Z0-9]*$"/>
+        </module>
+        <module name="PackageName"/>
+        <module name="ParameterName"/>
+        <module name="StaticVariableName"/>
+        <module name="TypeName"/>
+        <module name="AvoidStarImport"/>
+
+        <!-- whitespace -->
+        <module name="GenericWhitespace"/>
+        <module name="NoWhitespaceBefore"/>
+        <module name="WhitespaceAfter" />
+        <module name="NoWhitespaceAfter"/>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true"/>
+            <property name="allowEmptyMethods" value="true"/>
+        </module>
+        <module name="Indentation">
+            <property name="basicOffset" value="2"/>
+            <property name="caseIndent" value="2"/>
+        </module>
+        <module name="MethodParamPad"/>
+        <module name="ParenPad"/>
+        <module name="TypecastParenPad"/>
+    </module>
+</module>

--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkTestBase.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkTestBase.java
@@ -123,11 +123,41 @@ public class StorageSinkTestBase {
         .put("timestamp", timestamp);
   }
 
+  protected Schema createSchemaWithStringTimestampField() {
+    return SchemaBuilder.struct().name("record").version(1)
+            .field("boolean", Schema.BOOLEAN_SCHEMA)
+            .field("int", Schema.INT32_SCHEMA)
+            .field("long", Schema.INT64_SCHEMA)
+            .field("float", Schema.FLOAT32_SCHEMA)
+            .field("double", Schema.FLOAT64_SCHEMA)
+            .field("string", SchemaBuilder.string().defaultValue("abc").build())
+            .field("timestamp", Schema.STRING_SCHEMA)
+            .build();
+  }
+
+  protected Struct createRecordWithStringTimestampField(Schema newSchema, String timestamp) {
+    return new Struct(newSchema)
+            .put("boolean", true)
+            .put("int", 12)
+            .put("long", 12L)
+            .put("float", 12.2f)
+            .put("double", 12.2)
+            .put("string", "def")
+            .put("timestamp", timestamp);
+  }
+
   protected Struct createRecordWithNestedTimeField(long timestamp) {
     Schema nestedChildSchema = createSchemaWithTimestampField();
     Schema nestedSchema = SchemaBuilder.struct().field("nested", nestedChildSchema);
     return new Struct(nestedSchema)
       .put("nested", createRecordWithTimestampField(nestedChildSchema, timestamp));
+  }
+
+  protected Struct createRecordWithNestedStringTimeField(String timestamp) {
+    Schema nestedChildSchema = createSchemaWithStringTimestampField();
+    Schema nestedSchema = SchemaBuilder.struct().field("nested", nestedChildSchema);
+    return new Struct(nestedSchema)
+            .put("nested", createRecordWithStringTimestampField(nestedChildSchema, timestamp));
   }
 
   public void setUp() throws Exception {

--- a/core/src/main/java/io/confluent/connect/storage/StorageSinkTestBase.java
+++ b/core/src/main/java/io/confluent/connect/storage/StorageSinkTestBase.java
@@ -123,6 +123,13 @@ public class StorageSinkTestBase {
         .put("timestamp", timestamp);
   }
 
+  protected Struct createRecordWithNestedTimeField(long timestamp) {
+    Schema nestedChildSchema = createSchemaWithTimestampField();
+    Schema nestedSchema = SchemaBuilder.struct().field("nested", nestedChildSchema);
+    return new Struct(nestedSchema)
+      .put("nested", createRecordWithTimestampField(nestedChildSchema, timestamp));
+  }
+
   public void setUp() throws Exception {
     properties = createProps();
     Set<TopicPartition> assignment = new HashSet<>();

--- a/partitioner/pom.xml
+++ b/partitioner/pom.xml
@@ -37,8 +37,18 @@
             <version>${confluent.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-storage-core</artifactId>
+            <version>${confluent.version}</version>
+        </dependency>
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
     </dependencies>
+
 </project>

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/DefaultPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/DefaultPartitioner.java
@@ -38,7 +38,7 @@ public class DefaultPartitioner<T> implements Partitioner<T> {
   @Override
   public void configure(Map<String, Object> config) {
     partitionFields = newSchemaGenerator(config).newPartitionFields(PARTITION_FIELD);
-    delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+    delim = getDirectoryDelimiter(config);
   }
 
   @Override
@@ -54,6 +54,15 @@ public class DefaultPartitioner<T> implements Partitioner<T> {
   @Override
   public List<T> partitionFields() {
     return partitionFields;
+  }
+
+  protected String getDirectoryDelimiter(Map<String, Object> config) {
+    String delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+    if (delim == null) {
+      delim = StorageCommonConfig.DIRECTORY_DELIM_DEFAULT;
+
+    }
+    return delim;
   }
 
   @SuppressWarnings("unchecked")

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/FieldPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/FieldPartitioner.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
-import io.confluent.connect.storage.common.StorageCommonConfig;
 import io.confluent.connect.storage.errors.PartitionException;
 
 public class FieldPartitioner<T> extends DefaultPartitioner<T> {
@@ -36,7 +35,7 @@ public class FieldPartitioner<T> extends DefaultPartitioner<T> {
   public void configure(Map<String, Object> config) {
     fieldName = (String) config.get(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG);
     partitionFields = newSchemaGenerator(config).newPartitionFields(fieldName);
-    delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+    delim = getDirectoryDelimiter(config);
   }
 
   @Override

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/HourlyPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/HourlyPartitioner.java
@@ -23,13 +23,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import io.confluent.connect.storage.common.StorageCommonConfig;
-
 public class HourlyPartitioner<T> extends TimeBasedPartitioner<T> {
   @Override
   public void configure(Map<String, Object> config) {
     long partitionDurationMs = TimeUnit.HOURS.toMillis(1);
-    String delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+    delim = getDirectoryDelimiter(config);
     String pathFormat =
         "'year'=YYYY" + delim + "'month'=MM" + delim + "'day'=dd" + delim + "'hour'=HH";
 

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
@@ -98,6 +98,12 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
   public static final String TIMESTAMP_FIELD_NAME_DEFAULT = "timestamp";
   public static final String TIMESTAMP_FIELD_NAME_DISPLAY = "Record Field for Timestamp Extractor";
 
+  public static final String TIMESTAMP_FIELD_SOURCE_CONFIG = "timestamp.source";
+  public static final String TIMESTAMP_FIELD_SOURCE_DOC =
+          "The source of the record field to be used as timestamp by the timestamp extractor.";
+  public static final String TIMESTAMP_FIELD_SOURCE_DEFAULT = "value";
+  public static final String TIMESTAMP_FIELD_SOURCE_DISPLAY = "Source of the Record Field for Timestamp Extractor";
+
   // CHECKSTYLE:OFF
   public static final ConfigDef.Recommender partitionerClassDependentsRecommender =
       new PartitionerClassDependentsRecommender();
@@ -207,16 +213,26 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
           ++orderInGroup,
           Width.LONG,
           TIMESTAMP_FIELD_NAME_DISPLAY);
+
+      CONFIG_DEF.define(TIMESTAMP_FIELD_SOURCE_CONFIG,
+          Type.STRING,
+          TIMESTAMP_FIELD_SOURCE_DEFAULT,
+          Importance.MEDIUM,
+          TIMESTAMP_FIELD_SOURCE_DOC,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          TIMESTAMP_FIELD_SOURCE_DISPLAY);
     }
   }
 
   public static class BooleanParentRecommender implements ConfigDef.Recommender {
     protected final String parentConfigName;
-    
+
     public BooleanParentRecommender(String parentConfigName) {
       this.parentConfigName = parentConfigName;
     }
-    
+
     @Override
     public List<Object> validValues(String name, Map<String, Object> connectorConfigs) {
       return new LinkedList<>();

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/PartitionerConfig.java
@@ -100,7 +100,7 @@ public class PartitionerConfig extends AbstractConfig implements ComposableConfi
 
   public static final String TIMESTAMP_FIELD_SOURCE_CONFIG = "timestamp.source";
   public static final String TIMESTAMP_FIELD_SOURCE_DOC =
-          "The source of the record field to be used as timestamp by the timestamp extractor.";
+      "The source of the record field to be used as timestamp by the timestamp extractor, either key or value.";
   public static final String TIMESTAMP_FIELD_SOURCE_DEFAULT = "value";
   public static final String TIMESTAMP_FIELD_SOURCE_DISPLAY = "Source of the Record Field for Timestamp Extractor";
 

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedNestedKeyPartitoner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedNestedKeyPartitoner.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.storage.partitioner;
+
+        import org.apache.kafka.common.config.ConfigException;
+        import org.apache.kafka.common.utils.Time;
+        import org.apache.kafka.connect.connector.ConnectRecord;
+        import org.apache.kafka.connect.data.Field;
+        import org.apache.kafka.connect.data.Schema;
+        import org.apache.kafka.connect.data.Struct;
+        import org.apache.kafka.connect.data.Timestamp;
+        import org.apache.kafka.connect.errors.ConnectException;
+        import org.apache.kafka.connect.sink.SinkRecord;
+        import org.apache.kafka.connect.errors.DataException;
+        import org.joda.time.DateTime;
+        import org.joda.time.DateTimeZone;
+        import org.joda.time.format.DateTimeFormat;
+        import org.joda.time.format.DateTimeFormatter;
+        import org.joda.time.format.ISODateTimeFormat;
+        import org.slf4j.Logger;
+        import org.slf4j.LoggerFactory;
+
+        import java.lang.reflect.InvocationTargetException;
+        import java.util.Date;
+        import java.util.Locale;
+        import java.util.Map;
+
+        import io.confluent.connect.storage.common.SchemaGenerator;
+        import io.confluent.connect.storage.errors.PartitionException;
+
+public class TimeBasedNestedKeyPartitoner<T> extends DefaultPartitioner<T> {
+    // Duration of a partition in milliseconds.
+    private static final Logger log = LoggerFactory.getLogger(TimeBasedPartitioner.class);
+    private long partitionDurationMs;
+    private String pathFormat;
+    private DateTimeFormatter formatter;
+    protected TimestampExtractor timestampExtractor;
+
+    protected void init(
+            long partitionDurationMs,
+            String pathFormat,
+            Locale locale,
+            DateTimeZone timeZone,
+            Map<String, Object> config
+    ) {
+        delim = getDirectoryDelimiter(config);
+        this.partitionDurationMs = partitionDurationMs;
+        this.pathFormat = pathFormat;
+        this.formatter = getDateTimeFormatter(pathFormat, timeZone).withLocale(locale);
+        try {
+            partitionFields = newSchemaGenerator(config).newPartitionFields(pathFormat);
+            timestampExtractor = newTimestampExtractor(
+                    (String) config.get(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG));
+            timestampExtractor.configure(config);
+        } catch (IllegalArgumentException e) {
+            ConfigException ce = new ConfigException(
+                    PartitionerConfig.PATH_FORMAT_CONFIG,
+                    pathFormat,
+                    e.getMessage()
+            );
+            ce.initCause(e);
+            throw ce;
+        }
+    }
+
+    private static DateTimeFormatter getDateTimeFormatter(String str, DateTimeZone timeZone) {
+        return DateTimeFormat.forPattern(str).withZone(timeZone);
+    }
+
+    public static long getPartition(long timeGranularityMs, long timestamp, DateTimeZone timeZone) {
+        long adjustedTimestamp = timeZone.convertUTCToLocal(timestamp);
+        long partitionedTime = (adjustedTimestamp / timeGranularityMs) * timeGranularityMs;
+        return timeZone.convertLocalToUTC(partitionedTime, false);
+    }
+
+    public long getPartitionDurationMs() {
+        return partitionDurationMs;
+    }
+
+    public String getPathFormat() {
+        return pathFormat;
+    }
+
+    // public for testing
+    public TimestampExtractor getTimestampExtractor() {
+        return timestampExtractor;
+    }
+
+    @Override
+    public void configure(Map<String, Object> config) {
+        long partitionDurationMsProp =
+                (long) config.get(PartitionerConfig.PARTITION_DURATION_MS_CONFIG);
+        if (partitionDurationMsProp < 0) {
+            throw new ConfigException(
+                    PartitionerConfig.PARTITION_DURATION_MS_CONFIG,
+                    partitionDurationMsProp,
+                    "Partition duration needs to be a positive."
+            );
+        }
+
+        delim = getDirectoryDelimiter(config);
+        String pathFormat = (String) config.get(PartitionerConfig.PATH_FORMAT_CONFIG);
+        if (pathFormat.equals("") || pathFormat.equals(delim)) {
+            throw new ConfigException(
+                    PartitionerConfig.PATH_FORMAT_CONFIG,
+                    pathFormat,
+                    "Path format cannot be empty."
+            );
+        } else if (delim.equals(pathFormat.substring(pathFormat.length() - delim.length() - 1))) {
+            // Delimiter has been added by the user at the end of the path format string. Removing.
+            pathFormat = pathFormat.substring(0, pathFormat.length() - delim.length());
+        }
+
+        String localeString = (String) config.get(PartitionerConfig.LOCALE_CONFIG);
+        if (localeString.equals("")) {
+            throw new ConfigException(
+                    PartitionerConfig.LOCALE_CONFIG,
+                    localeString,
+                    "Locale cannot be empty."
+            );
+        }
+
+        String timeZoneString = (String) config.get(PartitionerConfig.TIMEZONE_CONFIG);
+        if (timeZoneString.equals("")) {
+            throw new ConfigException(
+                    PartitionerConfig.TIMEZONE_CONFIG,
+                    timeZoneString,
+                    "Timezone cannot be empty."
+            );
+        }
+
+        Locale locale = new Locale(localeString);
+        DateTimeZone timeZone = DateTimeZone.forID(timeZoneString);
+        init(partitionDurationMsProp, pathFormat, locale, timeZone, config);
+    }
+
+    @Override
+    public String encodePartition(SinkRecord sinkRecord) {
+        long timestamp = timestampExtractor.extract(sinkRecord);
+        DateTime bucket = new DateTime(
+                getPartition(partitionDurationMs, timestamp, formatter.getZone())
+        );
+        return bucket.toString(formatter);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public SchemaGenerator<T> newSchemaGenerator(Map<String, Object> config) {
+        Class<? extends SchemaGenerator<T>> generatorClass = null;
+        try {
+            generatorClass =
+                    (Class<? extends SchemaGenerator<T>>) config.get(
+                            PartitionerConfig.SCHEMA_GENERATOR_CLASS_CONFIG
+                    );
+            return generatorClass.getConstructor(Map.class).newInstance(config);
+        } catch (ClassCastException
+                | IllegalAccessException
+                | InstantiationException
+                | InvocationTargetException
+                | NoSuchMethodException e) {
+            ConfigException ce = new ConfigException("Invalid generator class: " + generatorClass);
+            ce.initCause(e);
+            throw ce;
+        }
+    }
+
+    public TimestampExtractor newTimestampExtractor(String extractorClassName) {
+        try {
+            switch (extractorClassName) {
+                case "Wallclock":
+                case "Record":
+                case "RecordField":
+                    extractorClassName = "io.confluent.connect.storage.partitioner.TimeBasedPartitioner$"
+                            + extractorClassName
+                            + "TimestampExtractor";
+                    break;
+                default:
+            }
+            Class<?> klass = Class.forName(extractorClassName);
+            if (!TimestampExtractor.class.isAssignableFrom(klass)) {
+                throw new ConnectException(
+                        "Class " + extractorClassName + " does not implement TimestampExtractor"
+                );
+            }
+            return (TimestampExtractor) klass.newInstance();
+        } catch (ClassNotFoundException
+                | ClassCastException
+                | IllegalAccessException
+                | InstantiationException e) {
+            ConfigException ce = new ConfigException(
+                    "Invalid timestamp extractor: " + extractorClassName
+            );
+            ce.initCause(e);
+            throw ce;
+        }
+    }
+
+    public static class WallclockTimestampExtractor implements TimestampExtractor {
+        @Override
+        public void configure(Map<String, Object> config) {}
+
+        @Override
+        public Long extract(ConnectRecord<?> record) {
+            return Time.SYSTEM.milliseconds();
+        }
+    }
+
+    public static class RecordTimestampExtractor implements TimestampExtractor {
+        @Override
+        public void configure(Map<String, Object> config) {}
+
+        @Override
+        public Long extract(ConnectRecord<?> record) {
+            return record.timestamp();
+        }
+    }
+
+    public static class RecordFieldTimestampExtractor implements TimestampExtractor {
+        private String fieldName;
+        private String fieldNameSource;
+        private DateTimeFormatter dateTime;
+
+        @Override
+        public void configure(Map<String, Object> config) {
+            fieldName = (String) config.get(PartitionerConfig.TIMESTAMP_FIELD_NAME_CONFIG);
+            fieldNameSource = (String) config.get(PartitionerConfig.TIMESTAMP_FIELD_SOURCE_CONFIG);
+            dateTime = ISODateTimeFormat.dateTimeParser();
+        }
+
+        @Override
+        public Long extract(ConnectRecord<?> record) {
+            Object source;
+            if (fieldNameSource.equals("key")) {
+                source = record.key();
+            } else {
+                source = record.value();
+            }
+
+            if (source instanceof Struct) {
+                Struct struct = (Struct) source;
+                Object timestampValue = getNestedFieldValue(struct);
+                Schema fieldSchema = getNestedField(record.valueSchema()).schema();
+
+                if (Timestamp.LOGICAL_NAME.equals(fieldSchema.name())) {
+                    return ((Date) timestampValue).getTime();
+                }
+
+                switch (fieldSchema.type()) {
+                    case INT32:
+                    case INT64:
+                        return ((Number) timestampValue).longValue();
+                    case STRING:
+                        return dateTime.parseMillis((String) timestampValue);
+                    default:
+                        log.error(
+                                "Unsupported type '{}' for user-defined timestamp field.",
+                                fieldSchema.type().getName()
+                        );
+                        throw new PartitionException(
+                                "Error extracting timestamp from record field: " + fieldName
+                        );
+                }
+            } else if (source instanceof Map) {
+                Map<?, ?> map = (Map<?, ?>) source;
+                Object timestampValue = getNestedFieldValue(map);
+                if (timestampValue instanceof Number) {
+                    return ((Number) timestampValue).longValue();
+                } else if (timestampValue instanceof String) {
+                    return dateTime.parseMillis((String) timestampValue);
+                } else if (timestampValue instanceof Date) {
+                    return ((Date) timestampValue).getTime();
+                } else {
+                    log.error(
+                            "Unsupported type '{}' for user-defined timestamp field.",
+                            timestampValue.getClass()
+                    );
+                    throw new PartitionException(
+                            "Error extracting timestamp from record field: " + fieldName
+                    );
+                }
+            } else {
+                log.error("Value is not of Struct or Map type.");
+                throw new PartitionException("Error encoding partition.");
+            }
+        }
+
+        private Object getField(Struct struct, String fieldName) {
+            Object field;
+            try {
+                field = struct.get(fieldName);
+            } catch (DataException e) {
+                throw new DataException(
+                        String.format("The field named '%s' does not exist.", fieldName), e);
+            }
+            return field;
+        }
+
+        private Object getNestedFieldValue(Struct struct) {
+            final String[] fieldNames = fieldName.split("\\.");
+            Struct tmpStruct = struct;
+            Object tmpObject;
+            try {
+                // Iterate down to final struct
+                int i = 0;
+                while (i < fieldNames.length - 1) {
+                    try {
+                        tmpObject = getField(tmpStruct, fieldNames[i]);
+                    } catch (DataException e) {
+                        throw new DataException(
+                                String.format("Unable to find nested field '%s'", fieldNames[i]));
+                    }
+                    tmpStruct = (Struct) tmpObject;
+                    i++;
+                }
+                // Extract from final struct
+                tmpObject = getField(tmpStruct, fieldNames[i]);
+            } catch (DataException e) {
+                throw new DataException(
+                        String.format("The nested field named '%s' does not exist.", fieldName), e);
+            }
+            return tmpObject;
+        }
+
+        private Object getNestedFieldValue(Map<?, ?> valueMap) {
+            final String[] fieldNames = fieldName.split("\\.");
+            Map<?, ?> tmpMap = valueMap;
+            Object tmpObject;
+            try {
+                // Iterate down to final map
+                int i = 0;
+                while (i < fieldNames.length - 1) {
+                    tmpObject = tmpMap.get(fieldNames[i]);
+                    if (tmpObject == null) {
+                        throw new DataException(
+                                String.format("Unable to find nested field '%s'", fieldNames[i]));
+                    }
+                    tmpMap = (Map<?, ?>) tmpObject;
+                    i++;
+                }
+                // Extract from final map
+                tmpObject = tmpMap.get(fieldNames[i]);
+                if (tmpObject == null) {
+                    throw new DataException(
+                            String.format("Unable to find nested field '%s'", fieldNames[i]));
+                }
+            } catch (DataException e) {
+                throw new DataException(
+                        String.format("The nested field named '%s' does not exist.", fieldName), e);
+            }
+            return tmpObject;
+        }
+
+        private Field getNestedField(Schema schema) {
+            final String[] fieldNames = fieldName.split("\\.");
+            if (fieldNames.length == 1) {
+                return schema.field(fieldName);
+            }
+            int i = 0;
+            Field tmpField = schema.field(fieldNames[i++]);
+            try {
+                // Iterate down to final schema
+                while (i < fieldNames.length - 1) {
+                    final String nestedFieldName = fieldNames[i];
+                    try {
+                        tmpField = tmpField.schema().field(nestedFieldName);
+                    } catch (DataException e) {
+                        throw new DataException(
+                                String.format("Unable to find nested field '%s'", nestedFieldName));
+                    }
+                    i++;
+                }
+                // Extract from final schema
+                tmpField = tmpField.schema().field(fieldNames[i]);
+            } catch (DataException e) {
+                throw new DataException(
+                        String.format("The nested field named '%s' does not exist.", fieldName), e);
+            }
+            return tmpField;
+        }
+    }
+}
+

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedNestedKeyPartitoner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedNestedKeyPartitoner.java
@@ -16,7 +16,6 @@
 
 package io.confluent.connect.storage.partitioner;
 
-        import java.util.Date;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.connector.ConnectRecord;

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedNestedKeyPartitoner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedNestedKeyPartitoner.java
@@ -16,381 +16,382 @@
 
 package io.confluent.connect.storage.partitioner;
 
-        import org.apache.kafka.common.config.ConfigException;
-        import org.apache.kafka.common.utils.Time;
-        import org.apache.kafka.connect.connector.ConnectRecord;
-        import org.apache.kafka.connect.data.Field;
-        import org.apache.kafka.connect.data.Schema;
-        import org.apache.kafka.connect.data.Struct;
-        import org.apache.kafka.connect.data.Timestamp;
-        import org.apache.kafka.connect.errors.ConnectException;
-        import org.apache.kafka.connect.sink.SinkRecord;
-        import org.apache.kafka.connect.errors.DataException;
-        import org.joda.time.DateTime;
-        import org.joda.time.DateTimeZone;
-        import org.joda.time.format.DateTimeFormat;
-        import org.joda.time.format.DateTimeFormatter;
-        import org.joda.time.format.ISODateTimeFormat;
-        import org.slf4j.Logger;
-        import org.slf4j.LoggerFactory;
-
-        import java.lang.reflect.InvocationTargetException;
         import java.util.Date;
-        import java.util.Locale;
-        import java.util.Map;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.errors.DataException;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-        import io.confluent.connect.storage.common.SchemaGenerator;
-        import io.confluent.connect.storage.errors.PartitionException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+
+import io.confluent.connect.storage.common.SchemaGenerator;
+import io.confluent.connect.storage.errors.PartitionException;
 
 public class TimeBasedNestedKeyPartitoner<T> extends DefaultPartitioner<T> {
-    // Duration of a partition in milliseconds.
-    private static final Logger log = LoggerFactory.getLogger(TimeBasedPartitioner.class);
-    private long partitionDurationMs;
-    private String pathFormat;
-    private DateTimeFormatter formatter;
-    protected TimestampExtractor timestampExtractor;
+  // Duration of a partition in milliseconds.
+  private static final Logger log = LoggerFactory.getLogger(TimeBasedPartitioner.class);
+  private long partitionDurationMs;
+  private String pathFormat;
+  private DateTimeFormatter formatter;
+  protected TimestampExtractor timestampExtractor;
 
-    protected void init(
-            long partitionDurationMs,
-            String pathFormat,
-            Locale locale,
-            DateTimeZone timeZone,
-            Map<String, Object> config
-    ) {
-        delim = getDirectoryDelimiter(config);
-        this.partitionDurationMs = partitionDurationMs;
-        this.pathFormat = pathFormat;
-        this.formatter = getDateTimeFormatter(pathFormat, timeZone).withLocale(locale);
-        try {
-            partitionFields = newSchemaGenerator(config).newPartitionFields(pathFormat);
-            timestampExtractor = newTimestampExtractor(
-                    (String) config.get(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG));
-            timestampExtractor.configure(config);
-        } catch (IllegalArgumentException e) {
-            ConfigException ce = new ConfigException(
-                    PartitionerConfig.PATH_FORMAT_CONFIG,
-                    pathFormat,
-                    e.getMessage()
-            );
-            ce.initCause(e);
-            throw ce;
-        }
+  protected void init(
+      long partitionDurationMs,
+      String pathFormat,
+      Locale locale,
+      DateTimeZone timeZone,
+      Map<String, Object> config
+  ) {
+    delim = getDirectoryDelimiter(config);
+    this.partitionDurationMs = partitionDurationMs;
+    this.pathFormat = pathFormat;
+    this.formatter = getDateTimeFormatter(pathFormat, timeZone).withLocale(locale);
+    try {
+      partitionFields = newSchemaGenerator(config).newPartitionFields(pathFormat);
+      timestampExtractor = newTimestampExtractor(
+        (String) config.get(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG));
+      timestampExtractor.configure(config);
+    } catch (IllegalArgumentException e) {
+      ConfigException ce = new ConfigException(
+          PartitionerConfig.PATH_FORMAT_CONFIG,
+          pathFormat,
+          e.getMessage()
+      );
+      ce.initCause(e);
+      throw ce;
+    }
+  }
+
+  private static DateTimeFormatter getDateTimeFormatter(String str, DateTimeZone timeZone) {
+    return DateTimeFormat.forPattern(str).withZone(timeZone);
+  }
+
+  public static long getPartition(long timeGranularityMs, long timestamp, DateTimeZone timeZone) {
+    long adjustedTimestamp = timeZone.convertUTCToLocal(timestamp);
+    long partitionedTime = (adjustedTimestamp / timeGranularityMs) * timeGranularityMs;
+    return timeZone.convertLocalToUTC(partitionedTime, false);
+  }
+
+  public long getPartitionDurationMs() {
+    return partitionDurationMs;
+  }
+
+  public String getPathFormat() {
+    return pathFormat;
+  }
+
+  // public for testing
+  public TimestampExtractor getTimestampExtractor() {
+    return timestampExtractor;
+  }
+
+  @Override
+  public void configure(Map<String, Object> config) {
+    long partitionDurationMsProp =
+        (long) config.get(PartitionerConfig.PARTITION_DURATION_MS_CONFIG);
+    if (partitionDurationMsProp < 0) {
+      throw new ConfigException(
+        PartitionerConfig.PARTITION_DURATION_MS_CONFIG,
+        partitionDurationMsProp,
+        "Partition duration needs to be a positive."
+      );
     }
 
-    private static DateTimeFormatter getDateTimeFormatter(String str, DateTimeZone timeZone) {
-        return DateTimeFormat.forPattern(str).withZone(timeZone);
+    delim = getDirectoryDelimiter(config);
+    String pathFormat = (String) config.get(PartitionerConfig.PATH_FORMAT_CONFIG);
+    if (pathFormat.equals("") || pathFormat.equals(delim)) {
+      throw new ConfigException(
+        PartitionerConfig.PATH_FORMAT_CONFIG,
+        pathFormat,
+        "Path format cannot be empty."
+      );
+    } else if (delim.equals(pathFormat.substring(pathFormat.length() - delim.length() - 1))) {
+      // Delimiter has been added by the user at the end of the path format string. Removing.
+      pathFormat = pathFormat.substring(0, pathFormat.length() - delim.length());
     }
 
-    public static long getPartition(long timeGranularityMs, long timestamp, DateTimeZone timeZone) {
-        long adjustedTimestamp = timeZone.convertUTCToLocal(timestamp);
-        long partitionedTime = (adjustedTimestamp / timeGranularityMs) * timeGranularityMs;
-        return timeZone.convertLocalToUTC(partitionedTime, false);
+    String localeString = (String) config.get(PartitionerConfig.LOCALE_CONFIG);
+    if (localeString.equals("")) {
+      throw new ConfigException(
+        PartitionerConfig.LOCALE_CONFIG,
+        localeString,
+        "Locale cannot be empty."
+      );
     }
 
-    public long getPartitionDurationMs() {
-        return partitionDurationMs;
+    String timeZoneString = (String) config.get(PartitionerConfig.TIMEZONE_CONFIG);
+    if (timeZoneString.equals("")) {
+      throw new ConfigException(
+        PartitionerConfig.TIMEZONE_CONFIG,
+        timeZoneString,
+        "Timezone cannot be empty."
+      );
     }
 
-    public String getPathFormat() {
-        return pathFormat;
-    }
+    Locale locale = new Locale(localeString);
+    DateTimeZone timeZone = DateTimeZone.forID(timeZoneString);
+    init(partitionDurationMsProp, pathFormat, locale, timeZone, config);
+  }
 
-    // public for testing
-    public TimestampExtractor getTimestampExtractor() {
-        return timestampExtractor;
+  @Override
+  public String encodePartition(SinkRecord sinkRecord) {
+    long timestamp = timestampExtractor.extract(sinkRecord);
+    DateTime bucket = new DateTime(
+        getPartition(partitionDurationMs, timestamp, formatter.getZone())
+    );
+    return bucket.toString(formatter);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public SchemaGenerator<T> newSchemaGenerator(Map<String, Object> config) {
+    Class<? extends SchemaGenerator<T>> generatorClass = null;
+    try {
+      generatorClass =
+        (Class<? extends SchemaGenerator<T>>) config.get(
+          PartitionerConfig.SCHEMA_GENERATOR_CLASS_CONFIG
+        );
+      return generatorClass.getConstructor(Map.class).newInstance(config);
+    } catch (ClassCastException
+      | IllegalAccessException
+      | InstantiationException
+      | InvocationTargetException
+      | NoSuchMethodException e) {
+      ConfigException ce = new ConfigException("Invalid generator class: " + generatorClass);
+      ce.initCause(e);
+      throw ce;
     }
+  }
+
+  public TimestampExtractor newTimestampExtractor(String extractorClassName) {
+    try {
+      switch (extractorClassName) {
+        case "Wallclock":
+        case "Record":
+        case "RecordField":
+          extractorClassName = "io.confluent.connect.storage.partitioner.TimeBasedPartitioner$"
+            + extractorClassName
+            + "TimestampExtractor";
+          break;
+        default:
+      }
+      Class<?> klass = Class.forName(extractorClassName);
+      if (!TimestampExtractor.class.isAssignableFrom(klass)) {
+        throw new ConnectException(
+          "Class " + extractorClassName + " does not implement TimestampExtractor"
+        );
+      }
+      return (TimestampExtractor) klass.newInstance();
+    } catch (ClassNotFoundException
+      | ClassCastException
+      | IllegalAccessException
+      | InstantiationException e) {
+      ConfigException ce = new ConfigException(
+          "Invalid timestamp extractor: " + extractorClassName
+      );
+      ce.initCause(e);
+      throw ce;
+    }
+  }
+
+  public static class WallclockTimestampExtractor implements TimestampExtractor {
+    @Override
+    public void configure(Map<String, Object> config) {}
+
+    @Override
+    public Long extract(ConnectRecord<?> record) {
+      return Time.SYSTEM.milliseconds();
+    }
+  }
+
+  public static class RecordTimestampExtractor implements TimestampExtractor {
+    @Override
+    public void configure(Map<String, Object> config) {}
+
+    @Override
+    public Long extract(ConnectRecord<?> record) {
+      return record.timestamp();
+    }
+  }
+
+  public static class RecordFieldTimestampExtractor implements TimestampExtractor {
+    private String fieldName;
+    private String fieldNameSource;
+    private DateTimeFormatter dateTime;
 
     @Override
     public void configure(Map<String, Object> config) {
-        long partitionDurationMsProp =
-                (long) config.get(PartitionerConfig.PARTITION_DURATION_MS_CONFIG);
-        if (partitionDurationMsProp < 0) {
-            throw new ConfigException(
-                    PartitionerConfig.PARTITION_DURATION_MS_CONFIG,
-                    partitionDurationMsProp,
-                    "Partition duration needs to be a positive."
-            );
-        }
-
-        delim = getDirectoryDelimiter(config);
-        String pathFormat = (String) config.get(PartitionerConfig.PATH_FORMAT_CONFIG);
-        if (pathFormat.equals("") || pathFormat.equals(delim)) {
-            throw new ConfigException(
-                    PartitionerConfig.PATH_FORMAT_CONFIG,
-                    pathFormat,
-                    "Path format cannot be empty."
-            );
-        } else if (delim.equals(pathFormat.substring(pathFormat.length() - delim.length() - 1))) {
-            // Delimiter has been added by the user at the end of the path format string. Removing.
-            pathFormat = pathFormat.substring(0, pathFormat.length() - delim.length());
-        }
-
-        String localeString = (String) config.get(PartitionerConfig.LOCALE_CONFIG);
-        if (localeString.equals("")) {
-            throw new ConfigException(
-                    PartitionerConfig.LOCALE_CONFIG,
-                    localeString,
-                    "Locale cannot be empty."
-            );
-        }
-
-        String timeZoneString = (String) config.get(PartitionerConfig.TIMEZONE_CONFIG);
-        if (timeZoneString.equals("")) {
-            throw new ConfigException(
-                    PartitionerConfig.TIMEZONE_CONFIG,
-                    timeZoneString,
-                    "Timezone cannot be empty."
-            );
-        }
-
-        Locale locale = new Locale(localeString);
-        DateTimeZone timeZone = DateTimeZone.forID(timeZoneString);
-        init(partitionDurationMsProp, pathFormat, locale, timeZone, config);
+      fieldName = (String) config.get(PartitionerConfig.TIMESTAMP_FIELD_NAME_CONFIG);
+      fieldNameSource = (String) config.get(PartitionerConfig.TIMESTAMP_FIELD_SOURCE_CONFIG);
+      dateTime = ISODateTimeFormat.dateTimeParser();
     }
 
     @Override
-    public String encodePartition(SinkRecord sinkRecord) {
-        long timestamp = timestampExtractor.extract(sinkRecord);
-        DateTime bucket = new DateTime(
-                getPartition(partitionDurationMs, timestamp, formatter.getZone())
-        );
-        return bucket.toString(formatter);
-    }
+    public Long extract(ConnectRecord<?> record) {
+      Object source;
+      if (fieldNameSource.equals("key")) {
+        source = record.key();
+      } else {
+        source = record.value();
+      }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public SchemaGenerator<T> newSchemaGenerator(Map<String, Object> config) {
-        Class<? extends SchemaGenerator<T>> generatorClass = null;
-        try {
-            generatorClass =
-                    (Class<? extends SchemaGenerator<T>>) config.get(
-                            PartitionerConfig.SCHEMA_GENERATOR_CLASS_CONFIG
-                    );
-            return generatorClass.getConstructor(Map.class).newInstance(config);
-        } catch (ClassCastException
-                | IllegalAccessException
-                | InstantiationException
-                | InvocationTargetException
-                | NoSuchMethodException e) {
-            ConfigException ce = new ConfigException("Invalid generator class: " + generatorClass);
-            ce.initCause(e);
-            throw ce;
+      if (source instanceof Struct) {
+        Struct struct = (Struct) source;
+        Object timestampValue = getNestedFieldValue(struct);
+        Schema fieldSchema = getNestedField(record.valueSchema()).schema();
+
+        if (Timestamp.LOGICAL_NAME.equals(fieldSchema.name())) {
+          return ((Date) timestampValue).getTime();
         }
-    }
 
-    public TimestampExtractor newTimestampExtractor(String extractorClassName) {
-        try {
-            switch (extractorClassName) {
-                case "Wallclock":
-                case "Record":
-                case "RecordField":
-                    extractorClassName = "io.confluent.connect.storage.partitioner.TimeBasedPartitioner$"
-                            + extractorClassName
-                            + "TimestampExtractor";
-                    break;
-                default:
-            }
-            Class<?> klass = Class.forName(extractorClassName);
-            if (!TimestampExtractor.class.isAssignableFrom(klass)) {
-                throw new ConnectException(
-                        "Class " + extractorClassName + " does not implement TimestampExtractor"
-                );
-            }
-            return (TimestampExtractor) klass.newInstance();
-        } catch (ClassNotFoundException
-                | ClassCastException
-                | IllegalAccessException
-                | InstantiationException e) {
-            ConfigException ce = new ConfigException(
-                    "Invalid timestamp extractor: " + extractorClassName
+        switch (fieldSchema.type()) {
+          case INT32:
+          case INT64:
+            return ((Number) timestampValue).longValue();
+          case STRING:
+            return dateTime.parseMillis((String) timestampValue);
+          default:
+            log.error(
+                "Unsupported type '{}' for user-defined timestamp field.",
+                fieldSchema.type().getName()
             );
-            ce.initCause(e);
-            throw ce;
+            throw new PartitionException(
+                "Error extracting timestamp from record field: " + fieldName
+            );
         }
+      } else if (source instanceof Map) {
+        Map<?, ?> map = (Map<?, ?>) source;
+        Object timestampValue = getNestedFieldValue(map);
+        if (timestampValue instanceof Number) {
+          return ((Number) timestampValue).longValue();
+        } else if (timestampValue instanceof String) {
+          return dateTime.parseMillis((String) timestampValue);
+        } else if (timestampValue instanceof Date) {
+          return ((Date) timestampValue).getTime();
+        } else {
+          log.error(
+              "Unsupported type '{}' for user-defined timestamp field.",
+              timestampValue.getClass()
+          );
+          throw new PartitionException(
+              "Error extracting timestamp from record field: " + fieldName
+          );
+        }
+      } else {
+        log.error("Value is not of Struct or Map type.");
+        throw new PartitionException("Error encoding partition.");
+      }
     }
 
-    public static class WallclockTimestampExtractor implements TimestampExtractor {
-        @Override
-        public void configure(Map<String, Object> config) {}
-
-        @Override
-        public Long extract(ConnectRecord<?> record) {
-            return Time.SYSTEM.milliseconds();
-        }
+    private Object getField(Struct struct, String fieldName) {
+      Object field;
+      try {
+        field = struct.get(fieldName);
+      } catch (DataException e) {
+        throw new DataException(
+          String.format("The field named '%s' does not exist.", fieldName), e);
+      }
+      return field;
     }
 
-    public static class RecordTimestampExtractor implements TimestampExtractor {
-        @Override
-        public void configure(Map<String, Object> config) {}
-
-        @Override
-        public Long extract(ConnectRecord<?> record) {
-            return record.timestamp();
+    private Object getNestedFieldValue(Struct struct) {
+      final String[] fieldNames = fieldName.split("\\.");
+      Struct tmpStruct = struct;
+      Object tmpObject;
+      try {
+        // Iterate down to final struct
+        int i = 0;
+        while (i < fieldNames.length - 1) {
+          try {
+            tmpObject = getField(tmpStruct, fieldNames[i]);
+          } catch (DataException e) {
+            throw new DataException(
+              String.format("Unable to find nested field '%s'", fieldNames[i]));
+          }
+          tmpStruct = (Struct) tmpObject;
+          i++;
         }
+        // Extract from final struct
+        tmpObject = getField(tmpStruct, fieldNames[i]);
+      } catch (DataException e) {
+        throw new DataException(
+          String.format("The nested field named '%s' does not exist.", fieldName), e);
+      }
+      return tmpObject;
     }
 
-    public static class RecordFieldTimestampExtractor implements TimestampExtractor {
-        private String fieldName;
-        private String fieldNameSource;
-        private DateTimeFormatter dateTime;
-
-        @Override
-        public void configure(Map<String, Object> config) {
-            fieldName = (String) config.get(PartitionerConfig.TIMESTAMP_FIELD_NAME_CONFIG);
-            fieldNameSource = (String) config.get(PartitionerConfig.TIMESTAMP_FIELD_SOURCE_CONFIG);
-            dateTime = ISODateTimeFormat.dateTimeParser();
+    private Object getNestedFieldValue(Map<?, ?> valueMap) {
+      final String[] fieldNames = fieldName.split("\\.");
+      Map<?, ?> tmpMap = valueMap;
+      Object tmpObject;
+      try {
+        // Iterate down to final map
+        int i = 0;
+        while (i < fieldNames.length - 1) {
+          tmpObject = tmpMap.get(fieldNames[i]);
+          if (tmpObject == null) {
+            throw new DataException(
+              String.format("Unable to find nested field '%s'", fieldNames[i]));
+          }
+          tmpMap = (Map<?, ?>) tmpObject;
+          i++;
         }
-
-        @Override
-        public Long extract(ConnectRecord<?> record) {
-            Object source;
-            if (fieldNameSource.equals("key")) {
-                source = record.key();
-            } else {
-                source = record.value();
-            }
-
-            if (source instanceof Struct) {
-                Struct struct = (Struct) source;
-                Object timestampValue = getNestedFieldValue(struct);
-                Schema fieldSchema = getNestedField(record.valueSchema()).schema();
-
-                if (Timestamp.LOGICAL_NAME.equals(fieldSchema.name())) {
-                    return ((Date) timestampValue).getTime();
-                }
-
-                switch (fieldSchema.type()) {
-                    case INT32:
-                    case INT64:
-                        return ((Number) timestampValue).longValue();
-                    case STRING:
-                        return dateTime.parseMillis((String) timestampValue);
-                    default:
-                        log.error(
-                                "Unsupported type '{}' for user-defined timestamp field.",
-                                fieldSchema.type().getName()
-                        );
-                        throw new PartitionException(
-                                "Error extracting timestamp from record field: " + fieldName
-                        );
-                }
-            } else if (source instanceof Map) {
-                Map<?, ?> map = (Map<?, ?>) source;
-                Object timestampValue = getNestedFieldValue(map);
-                if (timestampValue instanceof Number) {
-                    return ((Number) timestampValue).longValue();
-                } else if (timestampValue instanceof String) {
-                    return dateTime.parseMillis((String) timestampValue);
-                } else if (timestampValue instanceof Date) {
-                    return ((Date) timestampValue).getTime();
-                } else {
-                    log.error(
-                            "Unsupported type '{}' for user-defined timestamp field.",
-                            timestampValue.getClass()
-                    );
-                    throw new PartitionException(
-                            "Error extracting timestamp from record field: " + fieldName
-                    );
-                }
-            } else {
-                log.error("Value is not of Struct or Map type.");
-                throw new PartitionException("Error encoding partition.");
-            }
+        // Extract from final map
+        tmpObject = tmpMap.get(fieldNames[i]);
+        if (tmpObject == null) {
+          throw new DataException(
+            String.format("Unable to find nested field '%s'", fieldNames[i]));
         }
-
-        private Object getField(Struct struct, String fieldName) {
-            Object field;
-            try {
-                field = struct.get(fieldName);
-            } catch (DataException e) {
-                throw new DataException(
-                        String.format("The field named '%s' does not exist.", fieldName), e);
-            }
-            return field;
-        }
-
-        private Object getNestedFieldValue(Struct struct) {
-            final String[] fieldNames = fieldName.split("\\.");
-            Struct tmpStruct = struct;
-            Object tmpObject;
-            try {
-                // Iterate down to final struct
-                int i = 0;
-                while (i < fieldNames.length - 1) {
-                    try {
-                        tmpObject = getField(tmpStruct, fieldNames[i]);
-                    } catch (DataException e) {
-                        throw new DataException(
-                                String.format("Unable to find nested field '%s'", fieldNames[i]));
-                    }
-                    tmpStruct = (Struct) tmpObject;
-                    i++;
-                }
-                // Extract from final struct
-                tmpObject = getField(tmpStruct, fieldNames[i]);
-            } catch (DataException e) {
-                throw new DataException(
-                        String.format("The nested field named '%s' does not exist.", fieldName), e);
-            }
-            return tmpObject;
-        }
-
-        private Object getNestedFieldValue(Map<?, ?> valueMap) {
-            final String[] fieldNames = fieldName.split("\\.");
-            Map<?, ?> tmpMap = valueMap;
-            Object tmpObject;
-            try {
-                // Iterate down to final map
-                int i = 0;
-                while (i < fieldNames.length - 1) {
-                    tmpObject = tmpMap.get(fieldNames[i]);
-                    if (tmpObject == null) {
-                        throw new DataException(
-                                String.format("Unable to find nested field '%s'", fieldNames[i]));
-                    }
-                    tmpMap = (Map<?, ?>) tmpObject;
-                    i++;
-                }
-                // Extract from final map
-                tmpObject = tmpMap.get(fieldNames[i]);
-                if (tmpObject == null) {
-                    throw new DataException(
-                            String.format("Unable to find nested field '%s'", fieldNames[i]));
-                }
-            } catch (DataException e) {
-                throw new DataException(
-                        String.format("The nested field named '%s' does not exist.", fieldName), e);
-            }
-            return tmpObject;
-        }
-
-        private Field getNestedField(Schema schema) {
-            final String[] fieldNames = fieldName.split("\\.");
-            if (fieldNames.length == 1) {
-                return schema.field(fieldName);
-            }
-            int i = 0;
-            Field tmpField = schema.field(fieldNames[i++]);
-            try {
-                // Iterate down to final schema
-                while (i < fieldNames.length - 1) {
-                    final String nestedFieldName = fieldNames[i];
-                    try {
-                        tmpField = tmpField.schema().field(nestedFieldName);
-                    } catch (DataException e) {
-                        throw new DataException(
-                                String.format("Unable to find nested field '%s'", nestedFieldName));
-                    }
-                    i++;
-                }
-                // Extract from final schema
-                tmpField = tmpField.schema().field(fieldNames[i]);
-            } catch (DataException e) {
-                throw new DataException(
-                        String.format("The nested field named '%s' does not exist.", fieldName), e);
-            }
-            return tmpField;
-        }
+      } catch (DataException e) {
+        throw new DataException(
+          String.format("The nested field named '%s' does not exist.", fieldName), e);
+      }
+      return tmpObject;
     }
+
+    private Field getNestedField(Schema schema) {
+      final String[] fieldNames = fieldName.split("\\.");
+      if (fieldNames.length == 1) {
+        return schema.field(fieldName);
+      }
+      int i = 0;
+      Field tmpField = schema.field(fieldNames[i++]);
+      try {
+        // Iterate down to final schema
+        while (i < fieldNames.length - 1) {
+          final String nestedFieldName = fieldNames[i];
+          try {
+            tmpField = tmpField.schema().field(nestedFieldName);
+          } catch (DataException e) {
+            throw new DataException(
+              String.format("Unable to find nested field '%s'", nestedFieldName));
+          }
+          i++;
+        }
+        // Extract from final schema
+        tmpField = tmpField.schema().field(fieldNames[i]);
+      } catch (DataException e) {
+        throw new DataException(
+          String.format("The nested field named '%s' does not exist.", fieldName), e);
+      }
+      return tmpField;
+    }
+  }
 }
 

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
@@ -238,7 +238,7 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
     public void configure(Map<String, Object> config) {
       fieldName = (String) config.get(PartitionerConfig.TIMESTAMP_FIELD_NAME_CONFIG);
       fieldNameSource = (String) config.get(PartitionerConfig.TIMESTAMP_FIELD_SOURCE_CONFIG);
-      dateTime = ISODateTimeFormat.dateTime();
+      dateTime = ISODateTimeFormat.dateTimeParser();
     }
 
     @Override

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
@@ -19,13 +19,11 @@ package io.confluent.connect.storage.partitioner;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.connector.ConnectRecord;
-import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.apache.kafka.connect.errors.DataException;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
@@ -40,6 +38,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import io.confluent.connect.storage.common.SchemaGenerator;
+import io.confluent.connect.storage.common.StorageCommonConfig;
 import io.confluent.connect.storage.errors.PartitionException;
 
 public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
@@ -51,26 +50,26 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
   protected TimestampExtractor timestampExtractor;
 
   protected void init(
-      long partitionDurationMs,
-      String pathFormat,
-      Locale locale,
-      DateTimeZone timeZone,
-      Map<String, Object> config
+          long partitionDurationMs,
+          String pathFormat,
+          Locale locale,
+          DateTimeZone timeZone,
+          Map<String, Object> config
   ) {
-    delim = getDirectoryDelimiter(config);
+    delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
     this.partitionDurationMs = partitionDurationMs;
     this.pathFormat = pathFormat;
     this.formatter = getDateTimeFormatter(pathFormat, timeZone).withLocale(locale);
     try {
       partitionFields = newSchemaGenerator(config).newPartitionFields(pathFormat);
       timestampExtractor = newTimestampExtractor(
-          (String) config.get(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG));
+              (String) config.get(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG));
       timestampExtractor.configure(config);
     } catch (IllegalArgumentException e) {
       ConfigException ce = new ConfigException(
-          PartitionerConfig.PATH_FORMAT_CONFIG,
-          pathFormat,
-          e.getMessage()
+              PartitionerConfig.PATH_FORMAT_CONFIG,
+              pathFormat,
+              e.getMessage()
       );
       ce.initCause(e);
       throw ce;
@@ -103,22 +102,22 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
   @Override
   public void configure(Map<String, Object> config) {
     long partitionDurationMsProp =
-        (long) config.get(PartitionerConfig.PARTITION_DURATION_MS_CONFIG);
+            (long) config.get(PartitionerConfig.PARTITION_DURATION_MS_CONFIG);
     if (partitionDurationMsProp < 0) {
       throw new ConfigException(
-          PartitionerConfig.PARTITION_DURATION_MS_CONFIG,
-          partitionDurationMsProp,
-          "Partition duration needs to be a positive."
+              PartitionerConfig.PARTITION_DURATION_MS_CONFIG,
+              partitionDurationMsProp,
+              "Partition duration needs to be a positive."
       );
     }
 
-    delim = getDirectoryDelimiter(config);
+    String delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
     String pathFormat = (String) config.get(PartitionerConfig.PATH_FORMAT_CONFIG);
     if (pathFormat.equals("") || pathFormat.equals(delim)) {
       throw new ConfigException(
-          PartitionerConfig.PATH_FORMAT_CONFIG,
-          pathFormat,
-          "Path format cannot be empty."
+              PartitionerConfig.PATH_FORMAT_CONFIG,
+              pathFormat,
+              "Path format cannot be empty."
       );
     } else if (delim.equals(pathFormat.substring(pathFormat.length() - delim.length() - 1))) {
       // Delimiter has been added by the user at the end of the path format string. Removing.
@@ -128,18 +127,18 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
     String localeString = (String) config.get(PartitionerConfig.LOCALE_CONFIG);
     if (localeString.equals("")) {
       throw new ConfigException(
-          PartitionerConfig.LOCALE_CONFIG,
-          localeString,
-          "Locale cannot be empty."
+              PartitionerConfig.LOCALE_CONFIG,
+              localeString,
+              "Locale cannot be empty."
       );
     }
 
     String timeZoneString = (String) config.get(PartitionerConfig.TIMEZONE_CONFIG);
     if (timeZoneString.equals("")) {
       throw new ConfigException(
-          PartitionerConfig.TIMEZONE_CONFIG,
-          timeZoneString,
-          "Timezone cannot be empty."
+              PartitionerConfig.TIMEZONE_CONFIG,
+              timeZoneString,
+              "Timezone cannot be empty."
       );
     }
 
@@ -152,7 +151,7 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
   public String encodePartition(SinkRecord sinkRecord) {
     long timestamp = timestampExtractor.extract(sinkRecord);
     DateTime bucket = new DateTime(
-        getPartition(partitionDurationMs, timestamp, formatter.getZone())
+            getPartition(partitionDurationMs, timestamp, formatter.getZone())
     );
     return bucket.toString(formatter);
   }
@@ -163,15 +162,15 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
     Class<? extends SchemaGenerator<T>> generatorClass = null;
     try {
       generatorClass =
-          (Class<? extends SchemaGenerator<T>>) config.get(
-              PartitionerConfig.SCHEMA_GENERATOR_CLASS_CONFIG
-          );
+              (Class<? extends SchemaGenerator<T>>) config.get(
+                      PartitionerConfig.SCHEMA_GENERATOR_CLASS_CONFIG
+              );
       return generatorClass.getConstructor(Map.class).newInstance(config);
     } catch (ClassCastException
-        | IllegalAccessException
-        | InstantiationException
-        | InvocationTargetException
-        | NoSuchMethodException e) {
+            | IllegalAccessException
+            | InstantiationException
+            | InvocationTargetException
+            | NoSuchMethodException e) {
       ConfigException ce = new ConfigException("Invalid generator class: " + generatorClass);
       ce.initCause(e);
       throw ce;
@@ -185,24 +184,24 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
         case "Record":
         case "RecordField":
           extractorClassName = "io.confluent.connect.storage.partitioner.TimeBasedPartitioner$"
-              + extractorClassName
-              + "TimestampExtractor";
+                  + extractorClassName
+                  + "TimestampExtractor";
           break;
         default:
       }
       Class<?> klass = Class.forName(extractorClassName);
       if (!TimestampExtractor.class.isAssignableFrom(klass)) {
         throw new ConnectException(
-            "Class " + extractorClassName + " does not implement TimestampExtractor"
+                "Class " + extractorClassName + " does not implement TimestampExtractor"
         );
       }
       return (TimestampExtractor) klass.newInstance();
     } catch (ClassNotFoundException
-        | ClassCastException
-        | IllegalAccessException
-        | InstantiationException e) {
+            | ClassCastException
+            | IllegalAccessException
+            | InstantiationException e) {
       ConfigException ce = new ConfigException(
-          "Invalid timestamp extractor: " + extractorClassName
+              "Invalid timestamp extractor: " + extractorClassName
       );
       ce.initCause(e);
       throw ce;
@@ -231,29 +230,22 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
 
   public static class RecordFieldTimestampExtractor implements TimestampExtractor {
     private String fieldName;
-    private String fieldNameSource;
     private DateTimeFormatter dateTime;
 
     @Override
     public void configure(Map<String, Object> config) {
       fieldName = (String) config.get(PartitionerConfig.TIMESTAMP_FIELD_NAME_CONFIG);
-      fieldNameSource = (String) config.get(PartitionerConfig.TIMESTAMP_FIELD_SOURCE_CONFIG);
-      dateTime = ISODateTimeFormat.dateTimeParser();
+      dateTime = ISODateTimeFormat.dateTime();
     }
 
     @Override
     public Long extract(ConnectRecord<?> record) {
-      Object source;
-      if (fieldNameSource.equals("key")) {
-        source = record.key();
-      } else {
-        source = record.value();
-      }
-
-      if (source instanceof Struct) {
-        Struct struct = (Struct) source;
-        Object timestampValue = getNestedFieldValue(struct);
-        Schema fieldSchema = getNestedField(record.valueSchema()).schema();
+      Object value = record.value();
+      if (value instanceof Struct) {
+        Struct struct = (Struct) value;
+        Object timestampValue = struct.get(fieldName);
+        Schema valueSchema = record.valueSchema();
+        Schema fieldSchema = valueSchema.field(fieldName).schema();
 
         if (Timestamp.LOGICAL_NAME.equals(fieldSchema.name())) {
           return ((Date) timestampValue).getTime();
@@ -267,16 +259,16 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
             return dateTime.parseMillis((String) timestampValue);
           default:
             log.error(
-                "Unsupported type '{}' for user-defined timestamp field.",
-                fieldSchema.type().getName()
+                    "Unsupported type '{}' for user-defined timestamp field.",
+                    fieldSchema.type().getName()
             );
             throw new PartitionException(
-                "Error extracting timestamp from record field: " + fieldName
+                    "Error extracting timestamp from record field: " + fieldName
             );
         }
-      } else if (source instanceof Map) {
-        Map<?, ?> map = (Map<?, ?>) source;
-        Object timestampValue = getNestedFieldValue(map);
+      } else if (value instanceof Map) {
+        Map<?, ?> map = (Map<?, ?>) value;
+        Object timestampValue = map.get(fieldName);
         if (timestampValue instanceof Number) {
           return ((Number) timestampValue).longValue();
         } else if (timestampValue instanceof String) {
@@ -285,111 +277,17 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
           return ((Date) timestampValue).getTime();
         } else {
           log.error(
-              "Unsupported type '{}' for user-defined timestamp field.",
-              timestampValue.getClass()
+                  "Unsupported type '{}' for user-defined timestamp field.",
+                  timestampValue.getClass()
           );
           throw new PartitionException(
-              "Error extracting timestamp from record field: " + fieldName
+                  "Error extracting timestamp from record field: " + fieldName
           );
         }
       } else {
         log.error("Value is not of Struct or Map type.");
         throw new PartitionException("Error encoding partition.");
       }
-    }
-
-    private Object getField(Struct struct, String fieldName) {
-      Object field;
-      try {
-        field = struct.get(fieldName);
-      } catch (DataException e) {
-        throw new DataException(
-                String.format("The field named '%s' does not exist.", fieldName), e);
-      }
-      return field;
-    }
-
-    private Object getNestedFieldValue(Struct struct) {
-      final String[] fieldNames = fieldName.split("\\.");
-      Struct tmpStruct = struct;
-      Object tmpObject;
-      try {
-        // Iterate down to final struct
-        int i = 0;
-        while (i < fieldNames.length - 1) {
-          try {
-            tmpObject = getField(tmpStruct, fieldNames[i]);
-          } catch (DataException e) {
-            throw new DataException(
-                    String.format("Unable to find nested field '%s'", fieldNames[i]));
-          }
-          tmpStruct = (Struct) tmpObject;
-          i++;
-        }
-        // Extract from final struct
-        tmpObject = getField(tmpStruct, fieldNames[i]);
-      } catch (DataException e) {
-        throw new DataException(
-                String.format("The nested field named '%s' does not exist.", fieldName), e);
-      }
-      return tmpObject;
-    }
-
-    private Object getNestedFieldValue(Map<?, ?> valueMap) {
-      final String[] fieldNames = fieldName.split("\\.");
-      Map<?, ?> tmpMap = valueMap;
-      Object tmpObject;
-      try {
-        // Iterate down to final map
-        int i = 0;
-        while (i < fieldNames.length - 1) {
-          tmpObject = tmpMap.get(fieldNames[i]);
-          if (tmpObject == null) {
-            throw new DataException(
-                    String.format("Unable to find nested field '%s'", fieldNames[i]));
-          }
-          tmpMap = (Map<?, ?>) tmpObject;
-          i++;
-        }
-        // Extract from final map
-        tmpObject = tmpMap.get(fieldNames[i]);
-        if (tmpObject == null) {
-          throw new DataException(
-                  String.format("Unable to find nested field '%s'", fieldNames[i]));
-        }
-      } catch (DataException e) {
-        throw new DataException(
-                String.format("The nested field named '%s' does not exist.", fieldName), e);
-      }
-      return tmpObject;
-    }
-
-    private Field getNestedField(Schema schema) {
-      final String[] fieldNames = fieldName.split("\\.");
-      if (fieldNames.length == 1) {
-        return schema.field(fieldName);
-      }
-      int i = 0;
-      Field tmpField = schema.field(fieldNames[i++]);
-      try {
-        // Iterate down to final schema
-        while (i < fieldNames.length - 1) {
-          final String nestedFieldName = fieldNames[i];
-          try {
-            tmpField = tmpField.schema().field(nestedFieldName);
-          } catch (DataException e) {
-            throw new DataException(
-                    String.format("Unable to find nested field '%s'", nestedFieldName));
-          }
-          i++;
-        }
-        // Extract from final schema
-        tmpField = tmpField.schema().field(fieldNames[i]);
-      } catch (DataException e) {
-        throw new DataException(
-                String.format("The nested field named '%s' does not exist.", fieldName), e);
-      }
-      return tmpField;
     }
   }
 }

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
@@ -38,7 +38,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import io.confluent.connect.storage.common.SchemaGenerator;
-import io.confluent.connect.storage.common.StorageCommonConfig;
 import io.confluent.connect.storage.errors.PartitionException;
 
 public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
@@ -56,7 +55,7 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
       DateTimeZone timeZone,
       Map<String, Object> config
   ) {
-    delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+    delim = getDirectoryDelimiter(config);
     this.partitionDurationMs = partitionDurationMs;
     this.pathFormat = pathFormat;
     this.formatter = getDateTimeFormatter(pathFormat, timeZone).withLocale(locale);
@@ -111,7 +110,7 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
       );
     }
 
-    String delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+    String delim = getDirectoryDelimiter(config);
     String pathFormat = (String) config.get(PartitionerConfig.PATH_FORMAT_CONFIG);
     if (pathFormat.equals("") || pathFormat.equals(delim)) {
       throw new ConfigException(

--- a/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
+++ b/partitioner/src/main/java/io/confluent/connect/storage/partitioner/TimeBasedPartitioner.java
@@ -50,11 +50,11 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
   protected TimestampExtractor timestampExtractor;
 
   protected void init(
-          long partitionDurationMs,
-          String pathFormat,
-          Locale locale,
-          DateTimeZone timeZone,
-          Map<String, Object> config
+      long partitionDurationMs,
+      String pathFormat,
+      Locale locale,
+      DateTimeZone timeZone,
+      Map<String, Object> config
   ) {
     delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
     this.partitionDurationMs = partitionDurationMs;
@@ -63,13 +63,13 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
     try {
       partitionFields = newSchemaGenerator(config).newPartitionFields(pathFormat);
       timestampExtractor = newTimestampExtractor(
-              (String) config.get(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG));
+          (String) config.get(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG));
       timestampExtractor.configure(config);
     } catch (IllegalArgumentException e) {
       ConfigException ce = new ConfigException(
-              PartitionerConfig.PATH_FORMAT_CONFIG,
-              pathFormat,
-              e.getMessage()
+          PartitionerConfig.PATH_FORMAT_CONFIG,
+          pathFormat,
+          e.getMessage()
       );
       ce.initCause(e);
       throw ce;
@@ -102,12 +102,12 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
   @Override
   public void configure(Map<String, Object> config) {
     long partitionDurationMsProp =
-            (long) config.get(PartitionerConfig.PARTITION_DURATION_MS_CONFIG);
+        (long) config.get(PartitionerConfig.PARTITION_DURATION_MS_CONFIG);
     if (partitionDurationMsProp < 0) {
       throw new ConfigException(
-              PartitionerConfig.PARTITION_DURATION_MS_CONFIG,
-              partitionDurationMsProp,
-              "Partition duration needs to be a positive."
+          PartitionerConfig.PARTITION_DURATION_MS_CONFIG,
+          partitionDurationMsProp,
+          "Partition duration needs to be a positive."
       );
     }
 
@@ -115,9 +115,9 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
     String pathFormat = (String) config.get(PartitionerConfig.PATH_FORMAT_CONFIG);
     if (pathFormat.equals("") || pathFormat.equals(delim)) {
       throw new ConfigException(
-              PartitionerConfig.PATH_FORMAT_CONFIG,
-              pathFormat,
-              "Path format cannot be empty."
+          PartitionerConfig.PATH_FORMAT_CONFIG,
+          pathFormat,
+          "Path format cannot be empty."
       );
     } else if (delim.equals(pathFormat.substring(pathFormat.length() - delim.length() - 1))) {
       // Delimiter has been added by the user at the end of the path format string. Removing.
@@ -127,18 +127,18 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
     String localeString = (String) config.get(PartitionerConfig.LOCALE_CONFIG);
     if (localeString.equals("")) {
       throw new ConfigException(
-              PartitionerConfig.LOCALE_CONFIG,
-              localeString,
-              "Locale cannot be empty."
+          PartitionerConfig.LOCALE_CONFIG,
+          localeString,
+          "Locale cannot be empty."
       );
     }
 
     String timeZoneString = (String) config.get(PartitionerConfig.TIMEZONE_CONFIG);
     if (timeZoneString.equals("")) {
       throw new ConfigException(
-              PartitionerConfig.TIMEZONE_CONFIG,
-              timeZoneString,
-              "Timezone cannot be empty."
+          PartitionerConfig.TIMEZONE_CONFIG,
+          timeZoneString,
+          "Timezone cannot be empty."
       );
     }
 
@@ -151,7 +151,7 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
   public String encodePartition(SinkRecord sinkRecord) {
     long timestamp = timestampExtractor.extract(sinkRecord);
     DateTime bucket = new DateTime(
-            getPartition(partitionDurationMs, timestamp, formatter.getZone())
+        getPartition(partitionDurationMs, timestamp, formatter.getZone())
     );
     return bucket.toString(formatter);
   }
@@ -162,15 +162,15 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
     Class<? extends SchemaGenerator<T>> generatorClass = null;
     try {
       generatorClass =
-              (Class<? extends SchemaGenerator<T>>) config.get(
-                      PartitionerConfig.SCHEMA_GENERATOR_CLASS_CONFIG
-              );
+          (Class<? extends SchemaGenerator<T>>) config.get(
+              PartitionerConfig.SCHEMA_GENERATOR_CLASS_CONFIG
+          );
       return generatorClass.getConstructor(Map.class).newInstance(config);
     } catch (ClassCastException
-            | IllegalAccessException
-            | InstantiationException
-            | InvocationTargetException
-            | NoSuchMethodException e) {
+        | IllegalAccessException
+        | InstantiationException
+        | InvocationTargetException
+        | NoSuchMethodException e) {
       ConfigException ce = new ConfigException("Invalid generator class: " + generatorClass);
       ce.initCause(e);
       throw ce;
@@ -184,24 +184,24 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
         case "Record":
         case "RecordField":
           extractorClassName = "io.confluent.connect.storage.partitioner.TimeBasedPartitioner$"
-                  + extractorClassName
-                  + "TimestampExtractor";
+              + extractorClassName
+              + "TimestampExtractor";
           break;
         default:
       }
       Class<?> klass = Class.forName(extractorClassName);
       if (!TimestampExtractor.class.isAssignableFrom(klass)) {
         throw new ConnectException(
-                "Class " + extractorClassName + " does not implement TimestampExtractor"
+            "Class " + extractorClassName + " does not implement TimestampExtractor"
         );
       }
       return (TimestampExtractor) klass.newInstance();
     } catch (ClassNotFoundException
-            | ClassCastException
-            | IllegalAccessException
-            | InstantiationException e) {
+        | ClassCastException
+        | IllegalAccessException
+        | InstantiationException e) {
       ConfigException ce = new ConfigException(
-              "Invalid timestamp extractor: " + extractorClassName
+          "Invalid timestamp extractor: " + extractorClassName
       );
       ce.initCause(e);
       throw ce;
@@ -259,11 +259,11 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
             return dateTime.parseMillis((String) timestampValue);
           default:
             log.error(
-                    "Unsupported type '{}' for user-defined timestamp field.",
-                    fieldSchema.type().getName()
+                "Unsupported type '{}' for user-defined timestamp field.",
+                fieldSchema.type().getName()
             );
             throw new PartitionException(
-                    "Error extracting timestamp from record field: " + fieldName
+                "Error extracting timestamp from record field: " + fieldName
             );
         }
       } else if (value instanceof Map) {
@@ -277,11 +277,11 @@ public class TimeBasedPartitioner<T> extends DefaultPartitioner<T> {
           return ((Date) timestampValue).getTime();
         } else {
           log.error(
-                  "Unsupported type '{}' for user-defined timestamp field.",
-                  timestampValue.getClass()
+              "Unsupported type '{}' for user-defined timestamp field.",
+              timestampValue.getClass()
           );
           throw new PartitionException(
-                  "Error extracting timestamp from record field: " + fieldName
+              "Error extracting timestamp from record field: " + fieldName
           );
         }
       } else {

--- a/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedNestedKeyPartitonerTest.java
+++ b/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedNestedKeyPartitonerTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 
-public class TimeBasedPartitionerTest extends StorageSinkTestBase {
+public class TimeBasedNestedKeyPartitonerTest extends StorageSinkTestBase {
     private static final String timeZoneString = "America/New_York";
     private static final DateTimeZone DATE_TIME_ZONE = DateTimeZone.forID(timeZoneString);
 
@@ -37,7 +37,7 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
     public void testNestedRecordFieldTimestampExtractorFromKey() throws Exception {
         Map<String, Object> config = createConfig("nested.timestamp", "key");
 
-        TimestampExtractor timestampExtractor = new TimeBasedPartitioner.RecordFieldTimestampExtractor();
+        TimestampExtractor timestampExtractor = new TimeBasedNestedKeyPartitoner.RecordFieldTimestampExtractor();
         timestampExtractor.configure(config);
 
         long expectedTimestamp = new DateTime(2015, 4, 2, 1, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
@@ -51,7 +51,7 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
     public void testNestedRecordFieldTimestampExtractorFromValue() throws Exception {
         Map<String, Object> config = createConfig("nested.timestamp", "value");
 
-        TimestampExtractor timestampExtractor = new TimeBasedPartitioner.RecordFieldTimestampExtractor();
+        TimestampExtractor timestampExtractor = new TimeBasedNestedKeyPartitoner.RecordFieldTimestampExtractor();
         timestampExtractor.configure(config);
 
         long expectedTimestamp = new DateTime(2015, 4, 2, 1, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
@@ -65,7 +65,7 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
     public void testNestedRecordFieldTimestampExtractorFromKeyString() throws Exception {
         Map<String, Object> config = createConfig("nested.timestamp", "key");
 
-        TimestampExtractor timestampExtractor = new TimeBasedPartitioner.RecordFieldTimestampExtractor();
+        TimestampExtractor timestampExtractor = new TimeBasedNestedKeyPartitoner.RecordFieldTimestampExtractor();
         timestampExtractor.configure(config);
 
         String keyTimestamp = "2017-11-29T19:48:26-05:00";
@@ -83,7 +83,7 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
     public void testNestedRecordFieldTimestampExtractorFromValueString() throws Exception {
         Map<String, Object> config = createConfig("nested.timestamp", "value");
 
-        TimestampExtractor timestampExtractor = new TimeBasedPartitioner.RecordFieldTimestampExtractor();
+        TimestampExtractor timestampExtractor = new TimeBasedNestedKeyPartitoner.RecordFieldTimestampExtractor();
         timestampExtractor.configure(config);
 
         String keyTimestamp = "2017-11-29T19:48:26-05:00";

--- a/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
+++ b/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
@@ -102,8 +102,8 @@ public class TimeBasedPartitionerTest extends StorageSinkTestBase {
 
         config.put(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, "Record" +
                 (timeFieldName == null ? "" : "Field"));
-        config.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.HOURS.toMillis(1));
-        config.put(PartitionerConfig.PATH_FORMAT_CONFIG, "'year'=YYYY/'month'=M/'day'=d/'hour'=H/");
+        config.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.MINUTES.toMillis(30));
+        config.put(PartitionerConfig.PATH_FORMAT_CONFIG, "'aid=flipp'/'dt'=YYYY-MM-dd/'time_slot'=HHmm");
         config.put(PartitionerConfig.LOCALE_CONFIG, Locale.US.toString());
         config.put(PartitionerConfig.TIMEZONE_CONFIG, DATE_TIME_ZONE.toString());
         config.put(PartitionerConfig.TIMESTAMP_FIELD_SOURCE_CONFIG, timeFieldSource);

--- a/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
+++ b/partitioner/src/test/java/io/confluent/connect/storage/partitioner/TimeBasedPartitionerTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.connect.storage.partitioner;
+
+import io.confluent.connect.storage.StorageSinkTestBase;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class TimeBasedPartitionerTest extends StorageSinkTestBase {
+    private static final String timeZoneString = "America/New_York";
+    private static final DateTimeZone DATE_TIME_ZONE = DateTimeZone.forID(timeZoneString);
+    private BiHourlyPartitioner partitioner = new BiHourlyPartitioner();
+
+    @Test
+    public void testGeneratePartitionedPath() throws Exception {
+        Map<String, Object> config = createConfig(null);
+        partitioner.configure(config);
+
+        long timestamp = new DateTime(2015, 1, 1, 3, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
+        SinkRecord sinkRecord = createSinkRecord(timestamp);
+        String encodedPartition = partitioner.encodePartition(sinkRecord);
+        final String topic = "topic";
+        String path = partitioner.generatePartitionedPath(topic, encodedPartition);
+        assertEquals(topic+"/year=2015/month=January/day=01/hour=2/", path);
+    }
+
+    @Test
+    public void testDaylightSavingTime() {
+        DateTime time = new DateTime(2015, 11, 1, 2, 1, DATE_TIME_ZONE);
+        String pathFormat = "'year='YYYY/'month='MMMM/'day='dd/'hour='H/";
+        DateTimeFormatter formatter = DateTimeFormat.forPattern(pathFormat).withZone(DATE_TIME_ZONE);
+        long utc1 = DATE_TIME_ZONE.convertLocalToUTC(time.getMillis() - TimeUnit.MINUTES.toMillis(60), false);
+        long utc2 = DATE_TIME_ZONE.convertLocalToUTC(time.getMillis() - TimeUnit.MINUTES.toMillis(120), false);
+        DateTime time1 = new DateTime(DATE_TIME_ZONE.convertUTCToLocal(utc1));
+        DateTime time2 = new DateTime(DATE_TIME_ZONE.convertUTCToLocal(utc2));
+        assertEquals(time1.toString(formatter), time2.toString(formatter));
+    }
+
+    @Test
+    public void testRecordFieldTimeExtractor() throws Exception {
+        TimeBasedPartitioner<String> partitioner = new TimeBasedPartitioner<>();
+        Map<String, Object> config = createConfig("timestamp");
+        partitioner.configure(config);
+
+        long timestamp = new DateTime(2015, 4, 2, 1, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
+        SinkRecord sinkRecord = createSinkRecord(timestamp);
+
+        String encodedPartition = partitioner.encodePartition(sinkRecord);
+
+        assertEquals("year=2015/month=4/day=2/hour=1/", encodedPartition);
+    }
+
+    @Test
+    public void testNestedRecordFieldTimeExtractor() throws Exception {
+        TimeBasedPartitioner<String> partitioner = new TimeBasedPartitioner<>();
+        Map<String, Object> config = createConfig("nested.timestamp");
+        partitioner.configure(config);
+
+        long timestamp = new DateTime(2015, 4, 2, 1, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
+        SinkRecord sinkRecord = createSinkRecordWithNestedTimeField(timestamp);
+
+        String encodedPartition = partitioner.encodePartition(sinkRecord);
+
+        assertEquals("year=2015/month=4/day=2/hour=1/", encodedPartition);
+    }
+
+    @Test
+    public void testRecordTimeExtractor() throws Exception {
+        TimeBasedPartitioner<String> partitioner = new TimeBasedPartitioner<>();
+        Map<String, Object> config = createConfig(null);
+        partitioner.configure(config);
+
+        long timestamp = new DateTime(2015, 4, 2, 1, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
+        SinkRecord sinkRecord = createSinkRecord(timestamp);
+
+        String encodedPartition = partitioner.encodePartition(sinkRecord);
+
+        assertEquals("year=2015/month=4/day=2/hour=1/", encodedPartition);
+    }
+
+    private static class BiHourlyPartitioner extends TimeBasedPartitioner<String> {
+        private static long partitionDurationMs = TimeUnit.HOURS.toMillis(2);
+
+        @Override
+        public String getPathFormat() {
+            return "'year'=YYYY/'month'=MMMM/'day'=dd/'hour'=H/";
+        }
+
+        @Override
+        public void configure(Map<String, Object> config) {
+            init(partitionDurationMs, getPathFormat(), Locale.ENGLISH, DATE_TIME_ZONE, config);
+        }
+    }
+
+    private Map<String, Object> createConfig(String timeFieldName) {
+        Map<String, Object> config = new HashMap<>();
+
+        config.put(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, "Record" +
+                (timeFieldName == null ? "" : "Field"));
+        config.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.HOURS.toMillis(1));
+        config.put(PartitionerConfig.PATH_FORMAT_CONFIG, "'year'=YYYY/'month'=M/'day'=d/'hour'=H/");
+        config.put(PartitionerConfig.LOCALE_CONFIG, Locale.US.toString());
+        config.put(PartitionerConfig.TIMEZONE_CONFIG, DATE_TIME_ZONE.toString());
+        config.put(PartitionerConfig.SCHEMA_GENERATOR_CLASS_CONFIG, "io.confluent.connect.storage.hive.schema.TimeBasedSchemaGenerator");
+        if (timeFieldName != null) {
+            config.put(PartitionerConfig.TIMESTAMP_FIELD_NAME_CONFIG, timeFieldName);
+        }
+        return config;
+    }
+
+    private SinkRecord createSinkRecord(long timestamp) {
+        Schema schema = createSchemaWithTimestampField();
+        Struct record = createRecordWithTimestampField(schema, timestamp);
+        return new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null, schema, record, 0L,
+                timestamp, TimestampType.CREATE_TIME);
+    }
+
+    private SinkRecord createSinkRecordWithNestedTimeField(long timestamp) {
+        Struct record = createRecordWithNestedTimeField(timestamp);
+        return new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null, record.schema(), record, 0L,
+                timestamp, TimestampType.CREATE_TIME);
+    }
+}


### PR DESCRIPTION
#### [JIRA] What Jira tickets does this PR Address?
https://jira.wishabi.com/browse/DATA-4933

#### [SUMMARY] What's this PR do?
- [x] - Added support for use timestamps from the key
- [x] - Added support for use timestamps from nested avro objects
- [x] - Added unit tests for the new logic

#### [TEST CASES] How should this be tested?
- [x] - Run `mvn test` to make sure all test cases pass

#### [USAGE] How should this be used?
1. Run `mvn install` to generate the jar on local
2. Replace `/usr/share/java/kafka-connect-storage-common/kafka-connect-storage-partitioner-3.3.0.jar` with `/usr/share/java/kafka-connect-storage-common/kafka-connect-storage-partitioner-flipp-3.3.0.jar`
3. In s3 connector config file, add the following lines to use the customized timebased partitoner for nested timestamp in key:
```
partitioner.class=io.confluent.connect.storage.partitioner.TimeBasedNestedKeyPartitioner
timestamp.extractor=RecordField
timestamp.source=key
timestamp.field=nginx.time_iso8601
```