### PR TITLE
[Feature] DATA-4933: Add Customized Timebased Partitioner 4.0.0

### DIFF
--- a/flipp-partitioner/pom.xml
+++ b/flipp-partitioner/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kafka-connect-storage-common-parent</artifactId>
+        <groupId>io.confluent</groupId>
+        <version>4.0.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.flipp.datalib</groupId>
+    <artifactId>kafka-connect-storage-flipp-partitioner</artifactId>
+    <packaging>jar</packaging>
+    <name>kafka-connect-storage-flipp-partitioner</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-storage-common</artifactId>
+            <version>${confluent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-storage-core</artifactId>
+            <version>${confluent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-storage-partitioner</artifactId>
+            <version>${confluent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/flipp-partitioner/src/main/java/com/flipp/datalib/connect/storage/partitioner/TimeBasedNestedKeyPartitioner.java
+++ b/flipp-partitioner/src/main/java/com/flipp/datalib/connect/storage/partitioner/TimeBasedNestedKeyPartitioner.java
@@ -46,7 +46,7 @@ public class TimeBasedNestedKeyPartitioner<T> extends TimeBasedPartitioner<T> {
         case "Record":
         case "RecordField":
           extractorClassName =
-              "io.confluent.connect.storage.partitioner.TimeBasedNestedKeyPartitioner$"
+              "com.flipp.datalib.connect.storage.partitioner.TimeBasedNestedKeyPartitioner$"
               + extractorClassName
               + "TimestampExtractor";
           break;

--- a/flipp-partitioner/src/main/java/com/flipp/datalib/connect/storage/partitioner/TimeBasedNestedKeyPartitioner.java
+++ b/flipp-partitioner/src/main/java/com/flipp/datalib/connect/storage/partitioner/TimeBasedNestedKeyPartitioner.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipp.datalib.connect.storage.partitioner;
+
+import io.confluent.connect.storage.partitioner.TimeBasedPartitioner;
+import io.confluent.connect.storage.partitioner.TimestampExtractor;
+import io.confluent.connect.storage.errors.PartitionException;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+import java.util.Map;
+
+public class TimeBasedNestedKeyPartitioner<T> extends TimeBasedPartitioner<T> {
+  private static final Logger log = LoggerFactory.getLogger(TimeBasedNestedKeyPartitioner.class);
+
+  @Override
+  public TimestampExtractor newTimestampExtractor(String extractorClassName) {
+    try {
+      switch (extractorClassName) {
+        case "Wallclock":
+        case "Record":
+        case "RecordField":
+          extractorClassName =
+              "io.confluent.connect.storage.partitioner.TimeBasedNestedKeyPartitioner$"
+              + extractorClassName
+              + "TimestampExtractor";
+          break;
+        default:
+      }
+      Class<?> klass = Class.forName(extractorClassName);
+      if (!TimestampExtractor.class.isAssignableFrom(klass)) {
+        throw new ConnectException(
+            "Class " + extractorClassName + " does not implement TimestampExtractor"
+        );
+      }
+      return (TimestampExtractor) klass.newInstance();
+    } catch (ClassNotFoundException
+        | ClassCastException
+        | IllegalAccessException
+        | InstantiationException e) {
+      ConfigException ce = new ConfigException(
+          "Invalid timestamp extractor: " + extractorClassName
+      );
+      ce.initCause(e);
+      throw ce;
+    }
+  }
+
+  public static class RecordFieldTimestampExtractor implements TimestampExtractor {
+    private String fieldName;
+    private String fieldNameSource;
+    private DateTimeFormatter dateTime;
+
+    @Override
+    public void configure(Map<String, Object> config) {
+      fieldName = (String) config.get(
+          TimeBasedNestedKeyPartitionerConfig.TIMESTAMP_FIELD_NAME_CONFIG
+      );
+      fieldNameSource = (String) config.get(
+          TimeBasedNestedKeyPartitionerConfig.TIMESTAMP_FIELD_SOURCE_CONFIG
+      );
+      dateTime = ISODateTimeFormat.dateTimeParser();
+    }
+
+    @Override
+    public Long extract(ConnectRecord<?> record) {
+      Object source = getSource(record);
+      Schema sourceSchema = getSourceSchema(record);
+
+      if (source instanceof Struct) {
+        Struct struct = (Struct) source;
+        Object timestampValue = getNestedFieldValue(struct);
+        Schema fieldSchema = getNestedField(sourceSchema).schema();
+
+        if (Timestamp.LOGICAL_NAME.equals(fieldSchema.name())) {
+          return ((Date) timestampValue).getTime();
+        }
+
+        switch (fieldSchema.type()) {
+          case INT32:
+          case INT64:
+            return ((Number) timestampValue).longValue();
+          case STRING:
+            return dateTime.parseMillis((String) timestampValue);
+          default:
+            log.error(
+                "Unsupported type '{}' for user-defined timestamp field.",
+                fieldSchema.type().getName()
+            );
+            throw new PartitionException(
+                "Error extracting timestamp from record field: " + fieldName
+            );
+        }
+      } else if (source instanceof Map) {
+        Map<?, ?> map = (Map<?, ?>) source;
+        Object timestampValue = getNestedFieldValue(map);
+        if (timestampValue instanceof Number) {
+          return ((Number) timestampValue).longValue();
+        } else if (timestampValue instanceof String) {
+          return dateTime.parseMillis((String) timestampValue);
+        } else if (timestampValue instanceof Date) {
+          return ((Date) timestampValue).getTime();
+        } else {
+          log.error(
+              "Unsupported type '{}' for user-defined timestamp field.",
+              timestampValue.getClass()
+          );
+          throw new PartitionException(
+              "Error extracting timestamp from record field: " + fieldName
+          );
+        }
+      } else {
+        log.error("Value is not of Struct or Map type.");
+        throw new PartitionException("Error encoding partition.");
+      }
+    }
+
+    private Object getSource(ConnectRecord<?> record) {
+      return fieldNameSource.equals("key") ? record.key() : record.value();
+    }
+
+    private Schema getSourceSchema(ConnectRecord<?> record) {
+      return fieldNameSource.equals("key") ? record.keySchema() : record.valueSchema();
+    }
+
+    private Object getField(Struct struct, String fieldName) {
+      Object field;
+      try {
+        field = struct.get(fieldName);
+      } catch (DataException e) {
+        throw new DataException(
+            String.format("The field named '%s' does not exist.", fieldName), e);
+      }
+      return field;
+    }
+
+    private Object getNestedFieldValue(Struct struct) {
+      final String[] fieldNames = fieldName.split("\\.");
+      Struct tmpStruct = struct;
+      Object tmpObject;
+      try {
+        // Iterate down to final struct
+        int i = 0;
+        while (i < fieldNames.length - 1) {
+          try {
+            tmpObject = getField(tmpStruct, fieldNames[i]);
+          } catch (DataException e) {
+            throw new DataException(
+                String.format("Unable to find nested field '%s'", fieldNames[i]));
+          }
+          tmpStruct = (Struct) tmpObject;
+          i++;
+        }
+        // Extract from final struct
+        tmpObject = getField(tmpStruct, fieldNames[i]);
+      } catch (DataException e) {
+        throw new DataException(
+            String.format("The nested field named '%s' does not exist.", fieldName), e);
+      }
+      return tmpObject;
+    }
+
+    private Object getNestedFieldValue(Map<?, ?> valueMap) {
+      final String[] fieldNames = fieldName.split("\\.");
+      Map<?, ?> tmpMap = valueMap;
+      Object tmpObject;
+      try {
+        // Iterate down to final map
+        int i = 0;
+        while (i < fieldNames.length - 1) {
+          tmpObject = tmpMap.get(fieldNames[i]);
+          if (tmpObject == null) {
+            throw new DataException(
+                String.format("Unable to find nested field '%s'", fieldNames[i]));
+          }
+          tmpMap = (Map<?, ?>) tmpObject;
+          i++;
+        }
+        // Extract from final map
+        tmpObject = tmpMap.get(fieldNames[i]);
+        if (tmpObject == null) {
+          throw new DataException(
+              String.format("Unable to find nested field '%s'", fieldNames[i]));
+        }
+      } catch (DataException e) {
+        throw new DataException(
+            String.format("The nested field named '%s' does not exist.", fieldName), e);
+      }
+      return tmpObject;
+    }
+
+    private Field getNestedField(Schema schema) {
+      final String[] fieldNames = fieldName.split("\\.");
+      if (fieldNames.length == 1) {
+        return schema.field(fieldName);
+      }
+      int i = 0;
+      Field tmpField = schema.field(fieldNames[i++]);
+      try {
+        // Iterate down to final schema
+        while (i < fieldNames.length - 1) {
+          final String nestedFieldName = fieldNames[i];
+          try {
+            tmpField = tmpField.schema().field(nestedFieldName);
+          } catch (DataException e) {
+            throw new DataException(
+                String.format("Unable to find nested field '%s'", nestedFieldName));
+          }
+          i++;
+        }
+        // Extract from final schema
+        tmpField = tmpField.schema().field(fieldNames[i]);
+      } catch (DataException e) {
+        throw new DataException(
+            String.format("The nested field named '%s' does not exist.", fieldName), e);
+      }
+      return tmpField;
+    }
+  }
+}

--- a/flipp-partitioner/src/main/java/com/flipp/datalib/connect/storage/partitioner/TimeBasedNestedKeyPartitionerConfig.java
+++ b/flipp-partitioner/src/main/java/com/flipp/datalib/connect/storage/partitioner/TimeBasedNestedKeyPartitionerConfig.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flipp.datalib.connect.storage.partitioner;
+
+import io.confluent.connect.storage.partitioner.PartitionerConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Width;
+
+import java.util.Arrays;
+import java.util.Map;
+
+public class TimeBasedNestedKeyPartitionerConfig extends PartitionerConfig {
+  public static final String TIMESTAMP_FIELD_SOURCE_CONFIG = "timestamp.source";
+  public static final String TIMESTAMP_FIELD_SOURCE_DOC =
+      "The source of the record field to be used as timestamp "
+      + "by the timestamp extractor, either key or value.";
+  public static final String TIMESTAMP_FIELD_SOURCE_DEFAULT = "value";
+  public static final String TIMESTAMP_FIELD_SOURCE_DISPLAY =
+      "Source of the Record Field for Timestamp Extractor";
+
+  public static ConfigDef newConfigDef(ConfigDef.Recommender partitionerClassRecommender) {
+    ConfigDef configDef = new ConfigDef();
+    {
+      // Define Partitioner configuration group
+      final String group = "Partitioner";
+      int orderInGroup = 0;
+
+      configDef.define(PARTITIONER_CLASS_CONFIG,
+          Type.CLASS,
+          PARTITIONER_CLASS_DEFAULT,
+          Importance.HIGH,
+          PARTITIONER_CLASS_DOC,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          PARTITIONER_CLASS_DISPLAY,
+          Arrays.asList(
+              PARTITION_FIELD_NAME_CONFIG,
+              PARTITION_DURATION_MS_CONFIG,
+              PATH_FORMAT_CONFIG,
+              LOCALE_CONFIG,
+              TIMEZONE_CONFIG
+          ),
+          partitionerClassRecommender);
+
+      configDef.define(PARTITION_FIELD_NAME_CONFIG,
+          Type.STRING,
+          PARTITION_FIELD_NAME_DEFAULT,
+          Importance.MEDIUM,
+          PARTITION_FIELD_NAME_DOC,
+          group,
+          ++orderInGroup,
+          Width.NONE,
+          PARTITION_FIELD_NAME_DISPLAY,
+          new PartitionerClassDependentsRecommender());
+
+      configDef.define(PARTITION_DURATION_MS_CONFIG,
+          Type.LONG,
+          PARTITION_DURATION_MS_DEFAULT,
+          Importance.MEDIUM,
+          PARTITION_DURATION_MS_DOC,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          PARTITION_DURATION_MS_DISPLAY,
+          new PartitionerClassDependentsRecommender());
+
+      configDef.define(PATH_FORMAT_CONFIG,
+          Type.STRING,
+          PATH_FORMAT_DEFAULT,
+          Importance.MEDIUM,
+          PATH_FORMAT_DOC,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          PATH_FORMAT_DISPLAY,
+          new PartitionerClassDependentsRecommender());
+
+      configDef.define(LOCALE_CONFIG,
+          Type.STRING,
+          LOCALE_DEFAULT,
+          Importance.MEDIUM,
+          LOCALE_DOC,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          LOCALE_DISPLAY,
+          new PartitionerClassDependentsRecommender());
+
+      configDef.define(TIMEZONE_CONFIG,
+          Type.STRING,
+          TIMEZONE_DEFAULT,
+          Importance.MEDIUM,
+          TIMEZONE_DOC,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          TIMEZONE_DISPLAY,
+          new PartitionerClassDependentsRecommender());
+
+      configDef.define(TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
+          Type.STRING,
+          TIMESTAMP_EXTRACTOR_CLASS_DEFAULT,
+          Importance.MEDIUM,
+          TIMESTAMP_EXTRACTOR_CLASS_DOC,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          TIMESTAMP_EXTRACTOR_CLASS_DISPLAY);
+
+      configDef.define(TIMESTAMP_FIELD_NAME_CONFIG,
+          Type.STRING,
+          TIMESTAMP_FIELD_NAME_DEFAULT,
+          Importance.MEDIUM,
+          TIMESTAMP_FIELD_NAME_DOC,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          TIMESTAMP_FIELD_NAME_DISPLAY);
+
+      configDef.define(TIMESTAMP_FIELD_SOURCE_CONFIG,
+          Type.STRING,
+          TIMESTAMP_FIELD_SOURCE_DEFAULT,
+          Importance.MEDIUM,
+          TIMESTAMP_FIELD_SOURCE_DOC,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          TIMESTAMP_FIELD_SOURCE_DISPLAY);
+    }
+
+    return configDef;
+  }
+
+  public TimeBasedNestedKeyPartitionerConfig(ConfigDef configDef, Map<String, String> props) {
+    super(configDef, props);
+  }
+}

--- a/flipp-partitioner/src/test/java/com/flipp/datalib/connect/storage/partitioner/TimeBasedNestedKeyPartitionerTest.java
+++ b/flipp-partitioner/src/test/java/com/flipp/datalib/connect/storage/partitioner/TimeBasedNestedKeyPartitionerTest.java
@@ -1,0 +1,155 @@
+package com.flipp.datalib.connect.storage.partitioner;
+
+import io.confluent.connect.storage.StorageSinkTestBase;
+import io.confluent.connect.storage.partitioner.TimestampExtractor;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class TimeBasedNestedKeyPartitionerTest extends StorageSinkTestBase {
+  private static final String timeZoneString = "America/New_York";
+  private static final DateTimeZone DATE_TIME_ZONE = DateTimeZone.forID(timeZoneString);
+
+  @Test
+  public void testNestedRecordFieldTimestampExtractorFromKey() throws Exception {
+    Map<String, Object> config = createConfig("nested.timestamp", "key");
+
+    TimestampExtractor timestampExtractor = new TimeBasedNestedKeyPartitioner.RecordFieldTimestampExtractor();
+    timestampExtractor.configure(config);
+
+    long expectedTimestamp = new DateTime(2015, 4, 2, 1, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
+    SinkRecord sinkRecord = createSinkRecordWithNestedTimeField(expectedTimestamp, expectedTimestamp + 100);
+
+    long actualTimestamp = timestampExtractor.extract(sinkRecord);
+    assertEquals(expectedTimestamp, actualTimestamp);
+  }
+
+  @Test
+  public void testNestedRecordFieldTimestampExtractorFromValue() throws Exception {
+    Map<String, Object> config = createConfig("nested.timestamp", "value");
+
+    TimestampExtractor timestampExtractor = new TimeBasedNestedKeyPartitioner.RecordFieldTimestampExtractor();
+    timestampExtractor.configure(config);
+
+    long expectedTimestamp = new DateTime(2015, 4, 2, 1, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
+    SinkRecord sinkRecord = createSinkRecordWithNestedTimeField(expectedTimestamp + 100, expectedTimestamp);
+
+    long actualTimestamp = timestampExtractor.extract(sinkRecord);
+    assertEquals(expectedTimestamp, actualTimestamp);
+  }
+
+  @Test
+  public void testNestedRecordFieldTimestampExtractorFromKeyString() throws Exception {
+    Map<String, Object> config = createConfig("nested.timestamp", "key");
+
+    TimestampExtractor timestampExtractor = new TimeBasedNestedKeyPartitioner.RecordFieldTimestampExtractor();
+    timestampExtractor.configure(config);
+
+    String keyTimestamp = "2017-11-29T19:48:26-05:00";
+    String valueTimestamp = "2013-04-21T02:59:59-00:00";
+
+    DateTimeFormatter parser = ISODateTimeFormat.dateTimeParser();
+    long expectedTimestamp = parser.parseMillis(keyTimestamp);
+    SinkRecord sinkRecord = createSinkRecordWithNestedTimeFieldString(keyTimestamp, valueTimestamp, expectedTimestamp);
+
+    long actualTimestamp = timestampExtractor.extract(sinkRecord);
+    assertEquals(expectedTimestamp, actualTimestamp);
+  }
+
+  @Test
+  public void testNestedRecordFieldTimestampExtractorFromValueString() throws Exception {
+    Map<String, Object> config = createConfig("nested.timestamp", "value");
+
+    TimestampExtractor timestampExtractor = new TimeBasedNestedKeyPartitioner.RecordFieldTimestampExtractor();
+    timestampExtractor.configure(config);
+
+    String keyTimestamp = "2017-11-29T19:48:26-05:00";
+    String valueTimestamp = "2013-04-21T02:59:59-00:00";
+
+    DateTimeFormatter parser = ISODateTimeFormat.dateTimeParser();
+    long expectedTimestamp = parser.parseMillis(valueTimestamp);
+    SinkRecord sinkRecord = createSinkRecordWithNestedTimeFieldString(keyTimestamp, valueTimestamp, expectedTimestamp);
+
+    long actualTimestamp = timestampExtractor.extract(sinkRecord);
+    assertEquals(expectedTimestamp, actualTimestamp);
+  }
+
+  private Map<String, Object> createConfig(String timeFieldName, String timeFieldSource) {
+    Map<String, Object> config = new HashMap<>();
+
+    config.put(TimeBasedNestedKeyPartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, "Record" +
+        (timeFieldName == null ? "" : "Field"));
+    config.put(TimeBasedNestedKeyPartitionerConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.MINUTES.toMillis(30));
+    config.put(TimeBasedNestedKeyPartitionerConfig.PATH_FORMAT_CONFIG, "'aid=flipp'/'dt'=YYYY-MM-dd/'time_slot'=HHmm");
+    config.put(TimeBasedNestedKeyPartitionerConfig.LOCALE_CONFIG, Locale.US.toString());
+    config.put(TimeBasedNestedKeyPartitionerConfig.TIMEZONE_CONFIG, DATE_TIME_ZONE.toString());
+    config.put(TimeBasedNestedKeyPartitionerConfig.TIMESTAMP_FIELD_SOURCE_CONFIG, timeFieldSource);
+    if (timeFieldName != null) {
+      config.put(TimeBasedNestedKeyPartitionerConfig.TIMESTAMP_FIELD_NAME_CONFIG, timeFieldName);
+    }
+    return config;
+  }
+
+  private SinkRecord createSinkRecordWithNestedTimeField(long keyTimestamp, long valueTimestamp) {
+    Struct keyRecord = createRecordWithNestedTimeField(keyTimestamp);
+    Struct valueRecord = createRecordWithNestedTimeField(valueTimestamp);
+    return new SinkRecord(TOPIC, PARTITION, keyRecord.schema(), keyRecord, valueRecord.schema(), valueRecord, 0L,
+        keyTimestamp, TimestampType.CREATE_TIME);
+  }
+
+  private SinkRecord createSinkRecordWithNestedTimeFieldString(String keyTimestamp, String valueTimestamp, long timestamp) {
+    Struct keyRecord = createRecordWithNestedStringTimeField(keyTimestamp);
+    Struct valueRecord = createRecordWithNestedStringTimeField(valueTimestamp);
+    return new SinkRecord(TOPIC, PARTITION, keyRecord.schema(), keyRecord, valueRecord.schema(), valueRecord, 0L,
+        timestamp, TimestampType.CREATE_TIME);
+  }
+
+  private Schema createSchemaWithStringTimestampField() {
+    return SchemaBuilder.struct().name("record").version(1)
+        .field("boolean", Schema.BOOLEAN_SCHEMA)
+        .field("int", Schema.INT32_SCHEMA)
+        .field("long", Schema.INT64_SCHEMA)
+        .field("float", Schema.FLOAT32_SCHEMA)
+        .field("double", Schema.FLOAT64_SCHEMA)
+        .field("string", SchemaBuilder.string().defaultValue("abc").build())
+        .field("timestamp", Schema.STRING_SCHEMA)
+        .build();
+  }
+
+  private Struct createRecordWithStringTimestampField(Schema newSchema, String timestamp) {
+    return new Struct(newSchema)
+        .put("boolean", true)
+        .put("int", 12)
+        .put("long", 12L)
+        .put("float", 12.2f)
+        .put("double", 12.2)
+        .put("string", "def")
+        .put("timestamp", timestamp);
+  }
+
+  private Struct createRecordWithNestedTimeField(long timestamp) {
+    Schema nestedChildSchema = createSchemaWithTimestampField();
+    Schema nestedSchema = SchemaBuilder.struct().field("nested", nestedChildSchema);
+    return new Struct(nestedSchema)
+        .put("nested", createRecordWithTimestampField(nestedChildSchema, timestamp));
+  }
+
+  private Struct createRecordWithNestedStringTimeField(String timestamp) {
+    Schema nestedChildSchema = createSchemaWithStringTimestampField();
+    Schema nestedSchema = SchemaBuilder.struct().field("nested", nestedChildSchema);
+    return new Struct(nestedSchema)
+        .put("nested", createRecordWithStringTimestampField(nestedChildSchema, timestamp));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>
+                <artifactId>kafka-connect-storage-flipp-partitioner</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-storage-wal</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <module>format</module>
         <module>hive</module>
         <module>package-kafka-connect-storage-common</module>
+        <module>flipp-partitioner</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
#### [JIRA] What Jira tickets does this PR Address?
https://jira.wishabi.com/browse/DATA-4933

#### [SUMMARY] What's this PR do?
- [x] - Added support for use timestamps from the key in a separate jar
- [x] - Added support for use timestamps from nested avro objects
- [x] - Added unit tests for the new logic

#### [TEST CASES] How should this be tested?
- [x] - Run `mvn test` to make sure all test cases pass

#### [USAGE] How should this be used?
1. Run `mvn install` to generate the jar on local
2. Add the jar under `/usr/share/java/kafka-connect-storage-common/kafka-connect-storage-partitioner-flipp-4.0.0.jar`
3. In s3 connector config file, add the following lines to use the customized timebased partitoner for nested timestamp in key:
```
partitioner.class=io.confluent.connect.storage.partitioner.TimeBasedNestedKeyPartitioner
timestamp.extractor=RecordField
timestamp.source=key
timestamp.field=nginx.time_iso8601
```